### PR TITLE
Sub: 타입스크립트 파일 경로 분석기 작성

### DIFF
--- a/packages/code-generator/TypeScriptFilePathParser.test.ts
+++ b/packages/code-generator/TypeScriptFilePathParser.test.ts
@@ -1,0 +1,157 @@
+import { TypeScriptFilePathParser } from './TypeScriptFilePathParser';
+
+describe('TypeScriptFilePathParser', () => {
+  const normalPath =
+    '/home/theson/lookpin-prj/src/features/sonic/stores/boomSeries/sonicBoomSeries.effect.ts';
+  const relativePath =
+    './src/features/summer/stores/rainCloud/summerRainCloud.effect.ts';
+
+  describe('extractFeatureName', () => {
+    function extractFeatureName(value: string): string {
+      return new TypeScriptFilePathParser().extractFeatureName(
+        value.split('/')
+      );
+    }
+
+    it('분할된 경로에서 feature name 을 추출한다.', () => {
+      const result = extractFeatureName(normalPath);
+
+      expect(result).toBe('sonic');
+    });
+
+    it('상대 경로를 주어도 정상적으로 내용 추출 가능하다.', () => {
+      const result = extractFeatureName(relativePath);
+
+      expect(result).toBe('summer');
+    });
+
+    it('기능 모듈 폴더를 찾을 수 없으면 에러를 일으킨다.', () => {
+      expect(() =>
+        extractFeatureName('/home/blah/src/feat/components/Lookpin.tsx')
+      ).toThrowError();
+    });
+
+    it('기능 모듈 폴더를 찾았으나 그 이후 경로에 아무것도 없으면 에러를 일으킨다.', () => {
+      expect(() =>
+        extractFeatureName('/home/blah/src/features')
+      ).toThrowError();
+      expect(() =>
+        extractFeatureName('/home/blah/src/features/')
+      ).toThrowError();
+      expect(() => extractFeatureName('./src/features/')).toThrowError();
+    });
+  });
+
+  describe('extractSubName', () => {
+    function extractSubName(value: string): string {
+      return new TypeScriptFilePathParser().extractSubName(value.split('/'));
+    }
+
+    it('분할된 경로에서 sub name 을 추출한다.', () => {
+      const result = extractSubName(normalPath);
+
+      expect(result).toBe('boomSeries');
+    });
+
+    it('상대 경로를 주어도 정상적으로 추출 가능하다.', () => {
+      const result = extractSubName(relativePath);
+
+      expect(result).toBe('rainCloud');
+    });
+
+    it('sub name 을 추출할 수 없으면 에러를 일으킨다.', () => {
+      expect(() =>
+        extractSubName('/root/work/src/features/stores/nya.wtf.ts')
+      ).toThrowError();
+    });
+  });
+
+  describe('parse', () => {
+    const parser = new TypeScriptFilePathParser();
+
+    it('주어진 경로값을 분석하여 객체로 만든다.', () => {
+      const result = parser.parse(
+        '/home/theson/lookpin-prj/src/features/sonic/stores/boomSeries/sonicBoomSeries.effect.ts'
+      );
+
+      expect(result).toEqual({
+        fullName: 'sonicBoomSeries',
+        fullNameAsPascalCase: 'SonicBoomSeries',
+        featureName: 'sonic',
+        featureNameAsPascalCase: 'Sonic',
+        subName: 'boomSeries',
+        fileName: 'sonicBoomSeries.effect',
+        fileExt: 'ts',
+        fileNameAsPascalCase: 'SonicBoomSeriesEffect',
+      });
+    });
+
+    it('경로에 파일이 없을 경우, 파일명과 확장자는 빈값이다.', () => {
+      const result = parser.parse(
+        '/home/theson/lookpin-prj/src/features/sonic/stores/boomSeries'
+      );
+
+      expect(result).toEqual({
+        fullName: 'sonicBoomSeries',
+        fullNameAsPascalCase: 'SonicBoomSeries',
+        featureName: 'sonic',
+        featureNameAsPascalCase: 'Sonic',
+        subName: 'boomSeries',
+        fileName: '',
+        fileExt: '',
+        fileNameAsPascalCase: '',
+      });
+    });
+
+    it('경로에 sub name 이 포함 안되어있다면 오류를 일으킨다.', () => {
+      expect(() =>
+        parser.parse('/home/theson/lookpin-prj/src/features/sonic/stores')
+      ).toThrowError();
+    });
+
+    it('두가지 인자값을 넣으면 첫번째를 main feature, 두번째를 sub feature 로 인식한다.', () => {
+      const result = parser.parse('lookpin', 'search');
+
+      expect(result).toEqual({
+        fullName: 'lookpinSearch',
+        fullNameAsPascalCase: 'LookpinSearch',
+        featureName: 'lookpin',
+        featureNameAsPascalCase: 'Lookpin',
+        subName: 'search',
+        fileName: '',
+        fileExt: '',
+        fileNameAsPascalCase: '',
+      });
+    });
+
+    it('두가지 인자값을 넣었는데 두번째가 비었다면, sub feature 를 basic 으로 자동 인식한다.', () => {
+      const result = parser.parse('lookpin', '');
+
+      expect(result).toEqual({
+        fullName: 'lookpinBasic',
+        fullNameAsPascalCase: 'LookpinBasic',
+        featureName: 'lookpin',
+        featureNameAsPascalCase: 'Lookpin',
+        subName: 'basic',
+        fileName: '',
+        fileExt: '',
+        fileNameAsPascalCase: '',
+      });
+    });
+
+    it('두번째 인자가 문자열이 아니라면 sub feature 를 basic 으로 자동 인식한다.', () => {
+      const result = parser.parse('lookpin', undefined);
+
+      expect(result).toEqual({
+        fullName: 'lookpinBasic',
+        fullNameAsPascalCase: 'LookpinBasic',
+        featureName: 'lookpin',
+        featureNameAsPascalCase: 'Lookpin',
+        subName: 'basic',
+        fileName: '',
+        fileExt: '',
+        fileNameAsPascalCase: '',
+      });
+    });
+  });
+});

--- a/packages/code-generator/TypeScriptFilePathParser.ts
+++ b/packages/code-generator/TypeScriptFilePathParser.ts
@@ -1,0 +1,93 @@
+import { FeatureFileInfo } from './FeatureFileInfo';
+import { FeatureNameInfo } from './FeatureNameInfo';
+import { FeatureFileInfoDto, FilePathParser } from './types';
+import { isString } from './utils';
+
+export class TypeScriptFilePathParser implements FilePathParser {
+  static DEFAULT_SUB_NAME = 'basic';
+  private subLayerDic = {} as Record<string, boolean>;
+
+  constructor(
+    private featuresFolder = 'features',
+    private subLayers = ['components', 'stores'],
+    private extList = ['ts', 'tsx']
+  ) {
+    this.subLayerDic = subLayers.reduce((acc, sub) => {
+      acc[sub] = true;
+
+      return acc;
+    }, this.subLayerDic);
+  }
+
+  parseByNames(featureName: string, subName: string): FeatureFileInfoDto {
+    const featureNameInfo = new FeatureNameInfo(
+      featureName,
+      subName || TypeScriptFilePathParser.DEFAULT_SUB_NAME
+    );
+
+    return new FeatureFileInfo(featureNameInfo, '').toPlainObject();
+  }
+
+  parse(arg0: string, arg1?: string): FeatureFileInfoDto {
+    if (isString(arg1) || arguments.length > 1) {
+      return this.parseByNames(arg0, arg1 || '');
+    }
+    const path = arg0;
+    const splittedPath = path.split(/\/|\\/);
+
+    if (splittedPath.length === 1) {
+      splittedPath.push(TypeScriptFilePathParser.DEFAULT_SUB_NAME);
+    }
+
+    const endPoint = splittedPath[splittedPath.length - 1];
+    const isFile = this.extList.some((ext) => endPoint.endsWith(ext));
+    const featureName = this.extractFeatureName(splittedPath);
+    const subName = this.extractSubName(splittedPath);
+    const featureNameInfo = new FeatureNameInfo(featureName, subName);
+
+    return new FeatureFileInfo(
+      featureNameInfo,
+      isFile ? endPoint : ''
+    ).toPlainObject();
+  }
+
+  extractFeatureName(splittedPath: string[]) {
+    const index = splittedPath.indexOf(this.featuresFolder) + 1;
+
+    if (index <= 0) {
+      throw new Error(`extract fail - cannot found : "${this.featuresFolder}"`);
+    }
+
+    if (splittedPath.length <= index) {
+      throw new Error(`extract fail - incorrect index : ${index}`);
+    }
+
+    if (!splittedPath[index]) {
+      throw new Error('extract fail - empty path');
+    }
+
+    return splittedPath[index];
+  }
+
+  extractSubName(splittedPath: string[]) {
+    const values = this.subLayers.reduce((arr, sub) => {
+      const index = splittedPath.indexOf(sub) + 1;
+
+      if (index > 0) {
+        const value = splittedPath[index];
+
+        if (value && value.includes('.') === false) {
+          arr.push(value);
+        }
+      }
+
+      return arr;
+    }, [] as string[]);
+
+    if (values.length === 0) {
+      throw new Error('extract fail - sub name not found');
+    }
+
+    return values[0];
+  }
+}


### PR DESCRIPTION
## Updates

- 지정된 타입 스크립트 소스 파일의 경로를 이용하여 feature name 과 sub name 을 역으로 분석하는 클래스를 작성합니다.
- 본 기능은 모듈명을 변경하는 등의 기 작성된 파일에 추가 작업을 할 때 쓰일 예정입니다.