### PR TITLE
Hotfix: 빈 파일 생성 시 이미 존재할 때 발생되는 예외 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fe-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI tool for front-end develop with ts-fe-toolkit",
   "main": "./build/index.js",
   "scripts": {

--- a/packages/code-generator/CodeFileWriter.test.ts
+++ b/packages/code-generator/CodeFileWriter.test.ts
@@ -12,6 +12,7 @@ const {
   getConfig,
   getConfigForOverwriteTest,
   getConfigForAppendTest,
+  getConfigForNoTemplateTest,
   getFileInfo,
   getConfigForFolderTest,
 } = codeFileWriterFixtures;
@@ -31,8 +32,8 @@ function createMockFn() {
     return result;
   }) as TextFileReaderFn);
 
-  const write = vi.fn((async (path, _, forceOverwrite) => {
-    if (path.includes('already/exists') && !forceOverwrite) {
+  const write = vi.fn((async (path, data, forceOverwrite) => {
+    if (path.includes('already/exists') && data && !forceOverwrite) {
       return Promise.reject(new Error('already exists'));
     }
     return true;
@@ -165,6 +166,19 @@ describe('CodeFileWriterService', () => {
         false
       );
       expect(append).toBeCalled();
+    });
+    it('템플릿이 없으면 덮어씌우기를 하지 않는다.', async () => {
+      const config = getConfigForNoTemplateTest();
+
+      const result = await service.makeAll(config, fileInfo);
+
+      expect(result).toBe(1);
+      expect(write).toBeCalledWith(
+        `${config.base}/any/already/exists/${fileInfo.fullName}.ts`,
+        '',
+        false
+      );
+      expect(append).not.toBeCalled();
     });
   });
 

--- a/packages/code-generator/CodeFileWriter.ts
+++ b/packages/code-generator/CodeFileWriter.ts
@@ -64,7 +64,10 @@ export class CodeFileWriterService implements CodeFileWriter {
       `${basePath}/${featInfo.fileName}`,
       fileInfo
     );
-    const sourceCode = !template ? '' : await this.compile(template, fileInfo);
+    const hasTemplate = Boolean(template);
+    const sourceCode = hasTemplate
+      ? await this.compile(template, fileInfo)
+      : '';
     const { appendLogic } = featInfo;
 
     if (appendLogic) {
@@ -82,7 +85,7 @@ export class CodeFileWriterService implements CodeFileWriter {
       }
     }
 
-    await this.write(destPath, sourceCode, true);
+    await this.write(destPath, sourceCode, hasTemplate);
   }
 
   async makeAll(

--- a/packages/code-generator/_fixtures/CodeFileWriter.fixtures.ts
+++ b/packages/code-generator/_fixtures/CodeFileWriter.fixtures.ts
@@ -45,6 +45,18 @@ function getConfigForAppendTest(hasUnknownAppendLogic = false) {
   return config;
 }
 
+function getConfigForNoTemplateTest() {
+  const config: CodeGeneratorPathConfigDto = {
+    base: 'someSrcPath',
+    files: [
+      {
+        fileName: 'any/already/exists/{{fullName}}.ts',
+      },
+    ],
+  };
+  return config;
+}
+
 function getFileInfo() {
   const fileInfo: FeatureFileInfoDto = {
     fileName: 'LookpinInput',
@@ -87,4 +99,5 @@ export const codeFileWriterFixtures = {
   getConfigForAppendTest,
   getFileInfo,
   getConfigForFolderTest,
+  getConfigForNoTemplateTest,
 };

--- a/packages/code-generator/utils.ts
+++ b/packages/code-generator/utils.ts
@@ -66,8 +66,13 @@ export async function writeFile(
 ) {
   const isExists = await existsFile(targetPath);
 
-  if (isExists && !forceOverwrite) {
-    throw new Error(`"${targetPath}" file already exists`);
+  if (isExists) {
+    if (!source) {
+      return true;
+    }
+    if (!forceOverwrite) {
+      throw new Error(`"${targetPath}" file already exists`);
+    }
   }
 
   await fs.mkdir(dirname(targetPath), { recursive: true });


### PR DESCRIPTION
## Fixes <!-- 고쳐진 오류들 -->

- vscode 기준, 작업중인 프로젝트에서 모듈 생성 시 템플릿이 존재하지 않는 빈 파일을 생성할 때 발생되는 문제를 수정합니다.
- 상기 조건에서 이미 파일이 존재할 때 그 파일을 다시 덮어 씌우지 않도록 수정하였습니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- 테스트를 위해 미리 배포 진행합니다.