### PR TITLE
Feat: 서브 모듈 및 UI 컴포넌트 생성 기능 추가

### DIFF
--- a/cli-assets/config.json
+++ b/cli-assets/config.json
@@ -2,42 +2,46 @@
   "name": "ts-fe-toolkit default architecture config set",
   "stores": {
     "storeSub": {
-      "base": "src/features/{{featureName}}/stores/{{subName}}",
+      "base": "src/{{withFeature featureName}}/stores/{{subName}}",
+      "excludes": ["core", "common"],
       "files": [
         {
           "fileName": "{{fullName}}.effect.ts",
-          "template": "{{defTemplates}}store-sub-effect.ts.handlebars"
+          "template": "__defTemplates/store-sub-effect.ts.handlebars"
         },
         {
           "fileName": "{{fullName}}.slice.ts",
-          "template": "{{defTemplates}}store-sub-slice.ts.handlebars"
+          "template": "__defTemplates/store-sub-slice.ts.handlebars"
         },
         {
           "fileName": "{{fullName}}.selector.ts",
-          "template": "{{defTemplates}}store-sub-selector.ts.handlebars"
+          "template": "__defTemplates/store-sub-selector.ts.handlebars"
         },
         {
           "fileName": "index.ts",
-          "template": "{{defTemplates}}store-sub-index.ts.handlebars"
+          "template": "__defTemplates/store-sub-index.ts.handlebars"
         }
       ]
     },
     "storeRoot": {
-      "base": "src/features/{{featureName}}/stores",
+      "base": "src/{{withFeature featureName}}/stores",
+      "excludes": ["core", "common"],
       "files": [
         {
           "fileName": "index.ts",
-          "template": "{{defTemplates}}store-index.ts.handlebars",
+          "template": "__defTemplates/store-index.ts.handlebars",
           "appendLogic": "appendWithoutDuplicates"
         }
       ]
     },
     "featureRoot": {
-      "base": "src/features/{{featureName}}",
+      "base": "src/{{withFeature featureName}}",
+      "excludes": ["core"],
       "files": [
         {
+          "excludes": ["common"],
           "fileName": "reducers.ts",
-          "template": "{{defTemplates}}reducers.ts.handlebars",
+          "template": "__defTemplates/reducers.ts.handlebars",
           "appendLogic": "appendReducers"
         },
         {
@@ -55,19 +59,22 @@
           "folderName": "containers"
         },
         {
+          "excludes": ["shared"],
           "folderName": "pages"
         },
         {
+          "excludes": ["common", "shared"],
           "folderName": "contexts"
         }
       ]
     },
     "srcRoot": {
       "base": "src",
+      "excludes": ["core", "common", "shared"],
       "files": [
         {
           "fileName": "features/feat-reducers.ts",
-          "template": "{{defTemplates}}feat-reducers.ts.handlebars",
+          "template": "__defTemplates/feat-reducers.ts.handlebars",
           "appendLogic": "appendReducers"
         }
       ]
@@ -75,67 +82,74 @@
   },
   "components": {
     "normal": {
-      "base": "src/features/{{featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "excludes": ["core"],
       "files": [
         {
-          "fileName": "{{fileName}}.tsx",
-          "template": "{{defTemplates}}component-normal.tsx.handlebars"
+          "fileName": "{{fileNameAsPascalCase}}.tsx",
+          "template": "__defTemplates/component-normal.tsx.handlebars"
         }
       ]
     },
     "dialog": {
-      "base": "src/features/{{featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "excludes": ["core"],
       "files": [
         {
-          "fileName": "{{fileName}}.tsx",
-          "template": "{{defTemplates}}component-dialog.tsx.handlebars"
+          "fileName": "{{fileNameAsPascalCase}}.tsx",
+          "template": "__defTemplates/component-dialog.tsx.handlebars"
         }
       ]
     },
     "imperative": {
-      "base": "src/features/{{featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "excludes": ["core"],
       "files": [
         {
-          "fileName": "{{fileName}}.tsx",
-          "template": "{{defTemplates}}component-imperative.tsx.handlebars"
+          "fileName": "{{fileNameAsPascalCase}}.tsx",
+          "template": "__defTemplates/component-imperative.tsx.handlebars"
         }
       ]
     },
     "memo": {
-      "base": "src/features/{{featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "excludes": ["core"],
       "files": [
         {
-          "fileName": "{{fileName}}.tsx",
-          "template": "{{defTemplates}}component-memo.tsx.handlebars"
+          "fileName": "{{fileNameAsPascalCase}}.tsx",
+          "template": "__defTemplates/component-memo.tsx.handlebars"
         }
       ]
     }
   },
   "storybook": {
     "normal": {
-      "base": "src/features/{{featureName}}/components/{{subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components/{{subName}}/_stories",
+      "excludes": ["core"],
       "files": [
         {
-          "fileName": "{{fileName}}.stories.tsx",
-          "template": "{{defTemplates}}storybook-normal.stories.tsx.handlebars"
+          "fileName": "{{fileNameAsPascalCase}}.stories.tsx",
+          "template": "__defTemplates/storybook-normal.stories.tsx.handlebars"
         }
       ]
     },
     "dialog": {
-      "base": "src/features/{{featureName}}/components/{{subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components/{{subName}}/_stories",
+      "excludes": ["core"],
       "files": [
         {
-          "fileName": "{{fileName}}.stories.tsx",
-          "template": "{{defTemplates}}storybook-dialog.stories.tsx.handlebars"
+          "fileName": "{{fileNameAsPascalCase}}.stories.tsx",
+          "template": "__defTemplates/storybook-dialog.stories.tsx.handlebars"
         }
       ]
     },
     "imperative": {
-      "base": "src/features/{{featureName}}/components/{{subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components/{{subName}}/_stories",
+      "excludes": ["core"],
       "files": [
         {
-          "fileName": "{{fileName}}.stories.tsx",
-          "template": "{{defTemplates}}storybook-imperative.stories.tsx.handlebars"
+          "fileName": "{{fileNameAsPascalCase}}.stories.tsx",
+          "template": "__defTemplates/storybook-imperative.stories.tsx.handlebars"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-fe-cli",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "CLI tool for front-end develop with ts-fe-toolkit",
   "main": "./build/index.js",
   "scripts": {

--- a/packages/code-generator/_fixtures/CodeFileWriter.fixtures.ts
+++ b/packages/code-generator/_fixtures/CodeFileWriter.fixtures.ts
@@ -1,8 +1,13 @@
 import { CodeGeneratorPathConfigDto, FeatureFileInfoDto } from '../types';
+import { toCapitalize } from '../utils';
 
-function getConfig() {
+function getConfig(
+  parentExcludes: string[] = [],
+  childExcludes: string[] = []
+) {
   const config: CodeGeneratorPathConfigDto = {
-    base: 'src/feat/{{featureName}}/{{subName}}',
+    base: 'src/{{withFeature featureName}}/{{subName}}',
+    excludes: parentExcludes,
     files: [
       {
         fileName: '{{fileName}}Awesome.tsx',
@@ -10,6 +15,7 @@ function getConfig() {
         appendLogic: 'whatToDo',
       },
       {
+        excludes: childExcludes,
         fileName: '{{fileName}}.tsx',
         template: 'test2.tsx.handlebars',
       },
@@ -71,6 +77,27 @@ function getFileInfo() {
   return fileInfo;
 }
 
+function getSharedModuleInfo(
+  featureName = 'shared',
+  subName = 'memberInfo',
+  fileName = 'SortableList.tsx'
+) {
+  const featureNameAsPascalCase = toCapitalize(featureName);
+  const splittedFileName = fileName.split('.');
+
+  const fileInfo: FeatureFileInfoDto = {
+    fileName: splittedFileName[0],
+    fileExt: splittedFileName[1],
+    fileNameAsPascalCase: splittedFileName[0],
+    fullName: `${featureName}${toCapitalize(subName)}`,
+    fullNameAsPascalCase: `${featureNameAsPascalCase}${toCapitalize(subName)}`,
+    featureName,
+    featureNameAsPascalCase,
+    subName,
+  };
+  return fileInfo;
+}
+
 function getConfigForFolderTest() {
   const config: CodeGeneratorPathConfigDto = {
     base: 'someSrcPath/{{featureName}}',
@@ -98,6 +125,7 @@ export const codeFileWriterFixtures = {
   getConfigForOverwriteTest,
   getConfigForAppendTest,
   getFileInfo,
+  getSharedModuleInfo,
   getConfigForFolderTest,
   getConfigForNoTemplateTest,
 };

--- a/packages/code-generator/constants.ts
+++ b/packages/code-generator/constants.ts
@@ -1,1 +1,2 @@
 export const CLI_ASSETS_NAME = 'cli-assets';
+export const COMMON_FEATURE_NAMES = ['common', 'core', 'shared'] as const;

--- a/packages/code-generator/types.ts
+++ b/packages/code-generator/types.ts
@@ -1,3 +1,15 @@
+export type CodeGeneratorComponentsConfigKeyType =
+  | 'normal'
+  | 'dialog'
+  | 'imperative'
+  | 'memo';
+
+export type CodeGeneratorStoresConfigKeyType =
+  | 'storeSub'
+  | 'storeRoot'
+  | 'featureRoot'
+  | 'srcRoot';
+
 export interface FeatureNameInfoDto {
   fullName: string;
   fullNameAsPascalCase: string;
@@ -19,23 +31,9 @@ export interface FeatureFileInfoDto
 export interface FilePathParser {
   parse(path: string): FeatureFileInfoDto;
   parse(featureName: string, subName: string): FeatureFileInfoDto;
+  parseForComponent(path: string, componentName: string): FeatureFileInfoDto;
+  extractFeatureName(path: string): string;
 }
-
-export interface CodeGeneratorConfigModel {
-  module: CodeGeneratorModuleConfigDto;
-}
-
-export type CodeGeneratorComponentsConfigKeyType =
-  | 'normal'
-  | 'dialog'
-  | 'imperative'
-  | 'memo';
-
-export type CodeGeneratorStoresConfigKeyType =
-  | 'storeSub'
-  | 'storeRoot'
-  | 'featureRoot'
-  | 'srcRoot';
 
 export interface CodeGeneratorModuleConfigDto {
   name: string;
@@ -52,21 +50,22 @@ export interface CodeGeneratorModuleConfigDto {
 
 export interface CodeGeneratorFileConfigDto {
   fileName: string;
+  excludes?: string[];
   template?: string;
   appendLogic?: string;
 }
 
 export interface CodeGeneratorFolderConfigDto {
+  excludes?: string[];
   folderName: string;
 }
 
 export interface CodeGeneratorPathConfigDto {
   base: string;
   files: CodeGeneratorFileConfigDto[];
+  excludes?: string[];
   folders?: CodeGeneratorFolderConfigDto[];
 }
-
-
 
 export interface CodeGeneratorCLICommand {
   type: 'feat' | 'sub' | 'ui' | 'sb';


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- 서브 모듈과 UI 컴포넌트, 스토리북을 자동으로 생성하는 CLI 기능을 추가합니다.
- shared 나 common 에서 만들면 안되는 폴더 및 파일에 대한 예외처리를 위하여 `config.json` 에 `excludes` 항목을 추가하여 적용하였습니다.

## Others <!-- 기타 변경점들 (기능에 직접적인 연관이 없는 chore, style 등) -->

- config.json 내 기본 템플릿 경로를 `__defTemplates` 로 통합 & 변경하였습니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- 아직 여러가지로 미숙하여 코드가 점점 더러워지고(?) 있는점 양해바랍니다 🙏 
- 이 부분은 추 후 예정된 기능이 다 구현되면 다시 리팩터링하여 정리하겠습니다.
- 테스트를 위해 미리 운영 배포 되었기에 PR 종료 후 close 예정입니다.

## Refs

- https://github.com/thesoncriel/ts-fe-vscode-extension/pull/2