### PR TITLE
Hotfix: 컴포넌트 템플릿 내 잘못된 타입 참조 오류 수정

### DIFF
--- a/cli-assets/templates/component-dialog.tsx.handlebars
+++ b/cli-assets/templates/component-dialog.tsx.handlebars
@@ -1,6 +1,6 @@
 import { ReactNode, forwardRef, useImperativeHandle, useState, useRef } from 'react';
 import styled from 'styled-components';
-import { PromiseResolverDto } from 'jordy';
+import { PromiseResolver } from 'jordy';
 
 interface {{fileName}}Props {
   defaultShow?: boolean;
@@ -23,7 +23,7 @@ export const {{fileName}} = forwardRef<
   children,
   ...props,
 }, ref) => {
-  const refResolver = useRef<PromiseResolverDto<void> | null>(null);
+  const refResolver = useRef<PromiseResolver<void> | null>(null);
   const [show, setShow] = useState(defaultShow);
 
   useImperativeHandle(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI tool for front-end develop with jordy library",
   "main": "./build/index.js",
   "scripts": {


### PR DESCRIPTION
## Fixes <!-- 고쳐진 오류들 -->

- jordy 에서 PromiseResolverDto 가 아닌 `PromiseResolver` 가 쓰이므로 기존 템플릿 내용을 변경합니다.
