### PR TITLE
Feat: components 루트 경로에 UI Component 생성 가능하도록 기능 수정

### DIFF
--- a/cli-assets/config.json
+++ b/cli-assets/config.json
@@ -82,7 +82,7 @@
   },
   "components": {
     "normal": {
-      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
       "excludes": ["core"],
       "files": [
         {
@@ -92,7 +92,7 @@
       ]
     },
     "dialog": {
-      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
       "excludes": ["core"],
       "files": [
         {
@@ -102,7 +102,7 @@
       ]
     },
     "imperative": {
-      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
       "excludes": ["core"],
       "files": [
         {
@@ -112,7 +112,7 @@
       ]
     },
     "memo": {
-      "base": "src/{{withFeature featureName}}/components/{{subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
       "excludes": ["core"],
       "files": [
         {
@@ -124,7 +124,7 @@
   },
   "storybook": {
     "normal": {
-      "base": "src/{{withFeature featureName}}/components/{{subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components{{withSub subName}}/_stories",
       "excludes": ["core"],
       "files": [
         {
@@ -134,7 +134,7 @@
       ]
     },
     "dialog": {
-      "base": "src/{{withFeature featureName}}/components/{{subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components{{withSub subName}}/_stories",
       "excludes": ["core"],
       "files": [
         {
@@ -144,7 +144,7 @@
       ]
     },
     "imperative": {
-      "base": "src/{{withFeature featureName}}/components/{{subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components{{withSub subName}}/_stories",
       "excludes": ["core"],
       "files": [
         {

--- a/cli-assets/templates/storybook-dialog.stories.tsx.handlebars
+++ b/cli-assets/templates/storybook-dialog.stories.tsx.handlebars
@@ -16,7 +16,7 @@ const argTypesSetting: MyArgTypes = {
 };
 
 export default {
-  title: '{{featureName}}/{{subName}}/{{fileName}}',
+  title: '{{storybookTitle}}/{{fileName}}',
   component: {{fileName}},
   argTypes: argTypesSetting,
   parameters: { actions: { argTypesRegex: '^on.*' } }

--- a/cli-assets/templates/storybook-imperative.stories.tsx.handlebars
+++ b/cli-assets/templates/storybook-imperative.stories.tsx.handlebars
@@ -13,7 +13,7 @@ const argTypesSetting: MyArgTypes = {
 };
 
 export default {
-  title: '{{featureName}}/{{subName}}/{{fileName}}',
+  title: '{{storybookTitle}}/{{fileName}}',
   component: {{fileName}},
   argTypes: argTypesSetting,
   parameters: { actions: { argTypesRegex: '^on.*' } }

--- a/cli-assets/templates/storybook-normal.stories.tsx.handlebars
+++ b/cli-assets/templates/storybook-normal.stories.tsx.handlebars
@@ -11,7 +11,7 @@ const argTypesSetting: MyArgTypes = {
 };
 
 export default {
-  title: '{{featureName}}/{{subName}}/{{fileName}}',
+  title: '{{storybookTitle}}/{{fileName}}',
   component: {{fileName}},
   argTypes: argTypesSetting,
   parameters: { actions: { argTypesRegex: '^on.*' } }

--- a/cli-test.sh
+++ b/cli-test.sh
@@ -1,0 +1,8 @@
+npm run build
+node bin feat lookpin theson
+node bin ui sonicBoom/greenHill GreenHillZoneView
+node bin ui sonicBoom SonicRootView
+node bin sb ./src/common/components/tailsAdv/EmeraldHillZoneView.tsx
+node bin sb ./src/common/components/RootDefaultLayout.tsx
+node bin sb ./src/features/sonic/components/tailsAdv/EmeraldHillZoneView.tsx imperative
+node bin sb ./src/features/sonic/components/RootDefaultLayout.tsx memo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "CLI tool for front-end develop with jordy library",
   "main": "./build/index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "test:watch": "vitest watch",
     "prettier": "prettier './packages/**/*.ts'",
     "lint": "eslint 'packages/**'",
-    "test:feat": "npm run build && node bin feat add lookpin/theson"
+    "test:cli": "sh ./cli-test.sh"
   },
   "bin": {
     "jordy-cli": "./bin/index.js"

--- a/packages/code-generator/FeatureFileInfo.ts
+++ b/packages/code-generator/FeatureFileInfo.ts
@@ -22,6 +22,11 @@ export class FeatureFileInfo implements FeatureFileInfoDto {
   get fullNameAsPascalCase() {
     return this.config.fullNameAsPascalCase;
   }
+  get storybookTitle() {
+    return this.subName
+      ? `${this.featureName}/${this.subName}`
+      : this.featureName;
+  }
   get subName() {
     return this.config.subName;
   }
@@ -81,6 +86,7 @@ export class FeatureFileInfo implements FeatureFileInfoDto {
       fileExt: this.fileExt,
       fullName: this.fullName,
       fullNameAsPascalCase: this.fullNameAsPascalCase,
+      storybookTitle: this.storybookTitle,
       featureName: this.featureName,
       featureNameAsPascalCase: this.featureNameAsPascalCase,
       subName: this.subName,

--- a/packages/code-generator/FeatureNameInfo.test.ts
+++ b/packages/code-generator/FeatureNameInfo.test.ts
@@ -23,6 +23,10 @@ describe('FeatureNameConfig', () => {
     it('full name 을 PascalCase 로 가져올 수 있다.', () => {
       expect(config.fullNameAsPascalCase).toBe('MyPhoneBlockThing');
     });
+
+    it('storybook title 은 feature 와 sub 사이에 슬래시(/)가 포함된다.', () => {
+      expect(config.storybookTitle).toBe('myPhone/blockThing');
+    });
   });
 
   describe('feature 명칭만 설정', () => {
@@ -46,6 +50,10 @@ describe('FeatureNameConfig', () => {
 
     it('full name 을 PascalCase 로 가져올 수 있다.', () => {
       expect(config.fullNameAsPascalCase).toBe('MyPhone');
+    });
+
+    it('storybook title 은 feature 만 포함된다.', () => {
+      expect(config.storybookTitle).toBe('myPhone');
     });
   });
 });

--- a/packages/code-generator/FeatureNameInfo.ts
+++ b/packages/code-generator/FeatureNameInfo.ts
@@ -5,6 +5,7 @@ export class FeatureNameInfo implements FeatureNameInfoDto {
   private _featureNameAsPascalCase: string;
   private _fullNameAsPascalCase: string;
   private _fullName: string;
+  private _storybookTitle: string;
 
   get featureNameAsPascalCase() {
     return this._featureNameAsPascalCase;
@@ -14,6 +15,9 @@ export class FeatureNameInfo implements FeatureNameInfoDto {
   }
   get fullName() {
     return this._fullName;
+  }
+  get storybookTitle() {
+    return this._storybookTitle;
   }
 
   constructor(
@@ -25,6 +29,7 @@ export class FeatureNameInfo implements FeatureNameInfoDto {
     this._featureNameAsPascalCase = toCapitalize(featureName);
     this._fullNameAsPascalCase = `${this._featureNameAsPascalCase}${subNameAsPascalCase}`;
     this._fullName = `${featureName}${subNameAsPascalCase}`;
+    this._storybookTitle = subName ? `${featureName}/${subName}` : featureName;
   }
 
   toPlainObject(): FeatureNameInfoDto {
@@ -33,6 +38,7 @@ export class FeatureNameInfo implements FeatureNameInfoDto {
       featureNameAsPascalCase: this.featureNameAsPascalCase,
       fullName: this.fullName,
       fullNameAsPascalCase: this.fullNameAsPascalCase,
+      storybookTitle: this.storybookTitle,
       subName: this.subName,
     };
 

--- a/packages/code-generator/TypeScriptFilePathParser.test.ts
+++ b/packages/code-generator/TypeScriptFilePathParser.test.ts
@@ -89,6 +89,7 @@ describe('TypeScriptFilePathParser', () => {
       expect(result).toEqual({
         fullName: 'sonicBoomSeries',
         fullNameAsPascalCase: 'SonicBoomSeries',
+        storybookTitle: 'sonic/boomSeries',
         featureName: 'sonic',
         featureNameAsPascalCase: 'Sonic',
         subName: 'boomSeries',
@@ -106,6 +107,7 @@ describe('TypeScriptFilePathParser', () => {
       expect(result).toEqual({
         fullName: 'sonicBoomSeries',
         fullNameAsPascalCase: 'SonicBoomSeries',
+        storybookTitle: 'sonic/boomSeries',
         featureName: 'sonic',
         featureNameAsPascalCase: 'Sonic',
         subName: 'boomSeries',
@@ -121,12 +123,31 @@ describe('TypeScriptFilePathParser', () => {
       ).toThrowError();
     });
 
+    it('컴포넌트 경로에 sub name 이 포함 안되어있다면 sub name 은 빈값 취급된다.', () => {
+      const result = parser.parse(
+        '/home/theson/lookpin-prj/src/features/sonic/components/GreenHillView.tsx'
+      );
+
+      expect(result).toEqual({
+        fullName: 'sonic',
+        fullNameAsPascalCase: 'Sonic',
+        storybookTitle: 'sonic',
+        featureName: 'sonic',
+        featureNameAsPascalCase: 'Sonic',
+        subName: '',
+        fileName: 'GreenHillView',
+        fileExt: 'tsx',
+        fileNameAsPascalCase: 'GreenHillView',
+      });
+    });
+
     it('두가지 인자값을 넣으면 첫번째를 main feature, 두번째를 sub feature 로 인식한다.', () => {
       const result = parser.parse('lookpin', 'search');
 
       expect(result).toEqual({
         fullName: 'lookpinSearch',
         fullNameAsPascalCase: 'LookpinSearch',
+        storybookTitle: 'lookpin/search',
         featureName: 'lookpin',
         featureNameAsPascalCase: 'Lookpin',
         subName: 'search',
@@ -142,6 +163,7 @@ describe('TypeScriptFilePathParser', () => {
       expect(result).toEqual({
         fullName: 'lookpinBasic',
         fullNameAsPascalCase: 'LookpinBasic',
+        storybookTitle: 'lookpin/basic',
         featureName: 'lookpin',
         featureNameAsPascalCase: 'Lookpin',
         subName: 'basic',
@@ -157,6 +179,7 @@ describe('TypeScriptFilePathParser', () => {
       expect(result).toEqual({
         fullName: 'lookpinBasic',
         fullNameAsPascalCase: 'LookpinBasic',
+        storybookTitle: 'lookpin/basic',
         featureName: 'lookpin',
         featureNameAsPascalCase: 'Lookpin',
         subName: 'basic',
@@ -170,54 +193,119 @@ describe('TypeScriptFilePathParser', () => {
   describe('parseForComponent', () => {
     const parser = new TypeScriptFilePathParser();
 
-    it('모듈과 하위 모듈 명칭, 그리고 컴포넌트 명칭으로 분석된 결과를 만들수 있다.', () => {
-      const result = parser.parseForComponent('lookpin/search', 'SearchTable');
+    describe('모듈과 하위 모듈 명칭, 그리고 컴포넌트 명칭으로 분석된 결과를 만들수 있다.', () => {
+      it('하위 모듈 포함', () => {
+        const result = parser.parseForComponent(
+          'lookpin/search',
+          'SearchTable'
+        );
 
-      expect(result).toEqual({
-        fullName: 'lookpinSearch',
-        fullNameAsPascalCase: 'LookpinSearch',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: 'search',
-        fileName: 'SearchTable',
-        fileExt: 'tsx',
-        fileNameAsPascalCase: 'SearchTable',
+        expect(result).toEqual({
+          fullName: 'lookpinSearch',
+          fullNameAsPascalCase: 'LookpinSearch',
+          storybookTitle: 'lookpin/search',
+          featureName: 'lookpin',
+          featureNameAsPascalCase: 'Lookpin',
+          subName: 'search',
+          fileName: 'SearchTable',
+          fileExt: 'tsx',
+          fileNameAsPascalCase: 'SearchTable',
+        });
+      });
+      it('하위 모듈 없음', () => {
+        const result = parser.parseForComponent('lookpin', 'SearchTable');
+
+        expect(result).toEqual({
+          fullName: 'lookpin',
+          fullNameAsPascalCase: 'Lookpin',
+          storybookTitle: 'lookpin',
+          featureName: 'lookpin',
+          featureNameAsPascalCase: 'Lookpin',
+          subName: '',
+          fileName: 'SearchTable',
+          fileExt: 'tsx',
+          fileNameAsPascalCase: 'SearchTable',
+        });
       });
     });
 
-    it('실제 폴더 경로와 컴포넌트 명칭으로 의도대로 분석된다.', () => {
-      const result = parser.parseForComponent(
-        '/home/theson/work/myProject/src/features/lookpin/components/search',
-        'SearchTable'
-      );
+    describe('실제 폴더 경로와 컴포넌트 명칭으로 의도대로 분석된다.', () => {
+      it('하위 경로 포함', () => {
+        const result = parser.parseForComponent(
+          '/home/theson/work/myProject/src/features/lookpin/components/search',
+          'SearchTable'
+        );
 
-      expect(result).toEqual({
-        fullName: 'lookpinSearch',
-        fullNameAsPascalCase: 'LookpinSearch',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: 'search',
-        fileName: 'SearchTable',
-        fileExt: 'tsx',
-        fileNameAsPascalCase: 'SearchTable',
+        expect(result).toEqual({
+          fullName: 'lookpinSearch',
+          fullNameAsPascalCase: 'LookpinSearch',
+          storybookTitle: 'lookpin/search',
+          featureName: 'lookpin',
+          featureNameAsPascalCase: 'Lookpin',
+          subName: 'search',
+          fileName: 'SearchTable',
+          fileExt: 'tsx',
+          fileNameAsPascalCase: 'SearchTable',
+        });
+      });
+
+      it('하위 경로 없음', () => {
+        const result = parser.parseForComponent(
+          '/home/theson/work/myProject/src/features/lookpin/components',
+          'SearchTable'
+        );
+
+        expect(result).toEqual({
+          fullName: 'lookpin',
+          fullNameAsPascalCase: 'Lookpin',
+          storybookTitle: 'lookpin',
+          featureName: 'lookpin',
+          featureNameAsPascalCase: 'Lookpin',
+          subName: '',
+          fileName: 'SearchTable',
+          fileExt: 'tsx',
+          fileNameAsPascalCase: 'SearchTable',
+        });
       });
     });
 
-    it('상대 경로를 주어도 의도대로 분석된다.', () => {
-      const result = parser.parseForComponent(
-        './src/features/lookpin/components/search',
-        'SearchTable'
-      );
+    describe('상대 경로를 주어도 의도대로 분석된다.', () => {
+      it('하위경로 포함', () => {
+        const result = parser.parseForComponent(
+          './src/features/lookpin/components/search',
+          'SearchTable'
+        );
 
-      expect(result).toEqual({
-        fullName: 'lookpinSearch',
-        fullNameAsPascalCase: 'LookpinSearch',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: 'search',
-        fileName: 'SearchTable',
-        fileExt: 'tsx',
-        fileNameAsPascalCase: 'SearchTable',
+        expect(result).toEqual({
+          fullName: 'lookpinSearch',
+          fullNameAsPascalCase: 'LookpinSearch',
+          storybookTitle: 'lookpin/search',
+          featureName: 'lookpin',
+          featureNameAsPascalCase: 'Lookpin',
+          subName: 'search',
+          fileName: 'SearchTable',
+          fileExt: 'tsx',
+          fileNameAsPascalCase: 'SearchTable',
+        });
+      });
+
+      it('하위경로 없음', () => {
+        const result = parser.parseForComponent(
+          './src/features/lookpin/components',
+          'SearchTable'
+        );
+
+        expect(result).toEqual({
+          fullName: 'lookpin',
+          fullNameAsPascalCase: 'Lookpin',
+          storybookTitle: 'lookpin',
+          featureName: 'lookpin',
+          featureNameAsPascalCase: 'Lookpin',
+          subName: '',
+          fileName: 'SearchTable',
+          fileExt: 'tsx',
+          fileNameAsPascalCase: 'SearchTable',
+        });
       });
     });
 
@@ -228,11 +316,12 @@ describe('TypeScriptFilePathParser', () => {
       );
 
       expect(result).toEqual({
-        fullName: 'lookpinBasic',
-        fullNameAsPascalCase: 'LookpinBasic',
+        fullName: 'lookpin',
+        fullNameAsPascalCase: 'Lookpin',
+        storybookTitle: 'lookpin',
         featureName: 'lookpin',
         featureNameAsPascalCase: 'Lookpin',
-        subName: 'basic',
+        subName: '',
         fileName: 'OtherViewPanel',
         fileExt: 'tsx',
         fileNameAsPascalCase: 'OtherViewPanel',
@@ -246,11 +335,12 @@ describe('TypeScriptFilePathParser', () => {
       );
 
       expect(result).toEqual({
-        fullName: 'lookpinBasic',
-        fullNameAsPascalCase: 'LookpinBasic',
+        fullName: 'lookpin',
+        fullNameAsPascalCase: 'Lookpin',
+        storybookTitle: 'lookpin',
         featureName: 'lookpin',
         featureNameAsPascalCase: 'Lookpin',
-        subName: 'basic',
+        subName: '',
         fileName: 'OtherViewPanel',
         fileExt: 'tsx',
         fileNameAsPascalCase: 'OtherViewPanel',

--- a/packages/code-generator/TypeScriptFilePathParser.ts
+++ b/packages/code-generator/TypeScriptFilePathParser.ts
@@ -92,11 +92,16 @@ export class TypeScriptFilePathParser implements FilePathParser {
   }
 
   findSubNameFrom(splittedPath: string[]) {
+    let isComponents = false;
     const values = this.subLayers.reduce((arr, sub) => {
       const index = splittedPath.indexOf(sub) + 1;
 
       if (index > 0) {
         const value = splittedPath[index];
+
+        if (sub === 'components' && !isComponents) {
+          isComponents = true;
+        }
 
         if (value && value.includes('.') === false) {
           arr.push(value);
@@ -107,6 +112,9 @@ export class TypeScriptFilePathParser implements FilePathParser {
     }, [] as string[]);
 
     if (values.length === 0) {
+      if (isComponents) {
+        return '';
+      }
       throw new Error('extract fail - sub name not found');
     }
 
@@ -117,7 +125,7 @@ export class TypeScriptFilePathParser implements FilePathParser {
     try {
       return this.findSubNameFrom(splitPath);
     } catch (error) {
-      return TypeScriptFilePathParser.DEFAULT_SUB_NAME;
+      return '';
     }
   }
 
@@ -125,11 +133,13 @@ export class TypeScriptFilePathParser implements FilePathParser {
     const splitPath = path.split(/\/|\\/);
     let featureNameInfo;
 
-    if (splitPath.length <= 2) {
+    if (splitPath.length === 2) {
       featureNameInfo = new FeatureNameInfo(
         splitPath[0],
         splitPath[1] || TypeScriptFilePathParser.DEFAULT_SUB_NAME
       );
+    } else if (splitPath.length < 2) {
+      featureNameInfo = new FeatureNameInfo(splitPath[0]);
     } else {
       const featureName = this.findFeatureNameFrom(splitPath);
       const subName = this.tryFindSubNameFrom(splitPath);

--- a/packages/code-generator/cli.ts
+++ b/packages/code-generator/cli.ts
@@ -26,7 +26,7 @@ export default async function codeGeneratorCLI() {
   program
     .command('feat')
     .argument('<name>', 'feature name')
-    .argument('[sub]', 'sub-feature name (default : basic)')
+    .argument('[sub]', 'sub-feature name')
     .action((name, sub) => {
       const fileInfo = createFilePathParser().parse(name, sub);
 

--- a/packages/code-generator/types.ts
+++ b/packages/code-generator/types.ts
@@ -13,6 +13,7 @@ export type CodeGeneratorStoresConfigKeyType =
 export interface FeatureNameInfoDto {
   fullName: string;
   fullNameAsPascalCase: string;
+  storybookTitle: string;
   featureName: string;
   featureNameAsPascalCase: string;
   subName: string;

--- a/packages/code-generator/utils.ts
+++ b/packages/code-generator/utils.ts
@@ -8,6 +8,10 @@ Handlebars.registerHelper('withFeature', function (value) {
   return `${COMMON_FEATURE_NAMES.includes(value) ? '' : 'features/'}${value}`;
 });
 
+Handlebars.registerHelper('withSub', function (value) {
+  return value ? `/${value}` : '';
+});
+
 export function toCapitalize(value: string) {
   if (!value || typeof value !== 'string' || value.length === 0) {
     return '';


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- 기존에 sub feature name 을 반드시 입력해야 했기에 components root 경로에 컴포넌트를 바로 생성하지 못하던 문제를 개선합니다.

## Others

- 추가된 정책을 반영할 수 있도록 handlebars 템플릿과 config.json 설정 파일 내용을 일부 수정하였습니다.
- cli 로 파일 및 폴더 생성을 임의로 테스트 할 수 있도록 `test:cli` npm 스크립트를 추가하였습니다.
  - 이 명령은 cli 명령 여러개가 포함된 `cli-test.sh` 파일을 수행합니다.
  - 필요하다면 이 쉘스크립트 파일 내용을 변경하여 각종 파일 및 폴더 생성 테스트를 해 볼 수 있습니다.

## Notes <!-- 리뷰어에게 알려줄 내용이나 PR에 히스토리로 남기고 싶은 내용들 -->

- 후속 기능인 vscode extension 테스트를 위해 미리 배포 했습니다.
- 코드 리뷰가 끝나면 PR을 종료 할 예정입니다.
