### PR TITLE
Feat: 디자인 시스템 모듈에 대한 UI 컴포넌트 생성 로직 추가

### DIFF
--- a/cli-assets/config.json
+++ b/cli-assets/config.json
@@ -2,7 +2,7 @@
   "name": "jordy default architecture config set",
   "stores": {
     "storeSub": {
-      "base": "src/{{withFeature featureName}}/stores/{{subName}}",
+      "base": "src/{{withFeature featureName}}/stores/{{subPath}}",
       "excludes": ["core", "common"],
       "files": [
         {
@@ -82,7 +82,7 @@
   },
   "components": {
     "normal": {
-      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSubPath subPath}}",
       "excludes": ["core"],
       "files": [
         {
@@ -92,7 +92,7 @@
       ]
     },
     "dialog": {
-      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSubPath subPath}}",
       "excludes": ["core"],
       "files": [
         {
@@ -102,7 +102,7 @@
       ]
     },
     "imperative": {
-      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSubPath subPath}}",
       "excludes": ["core"],
       "files": [
         {
@@ -112,7 +112,7 @@
       ]
     },
     "memo": {
-      "base": "src/{{withFeature featureName}}/components{{withSub subName}}",
+      "base": "src/{{withFeature featureName}}/components{{withSubPath subPath}}",
       "excludes": ["core"],
       "files": [
         {
@@ -124,7 +124,7 @@
   },
   "storybook": {
     "normal": {
-      "base": "src/{{withFeature featureName}}/components{{withSub subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components{{withSubPath subPath}}/_stories",
       "excludes": ["core"],
       "files": [
         {
@@ -134,7 +134,7 @@
       ]
     },
     "dialog": {
-      "base": "src/{{withFeature featureName}}/components{{withSub subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components{{withSubPath subPath}}/_stories",
       "excludes": ["core"],
       "files": [
         {
@@ -144,7 +144,7 @@
       ]
     },
     "imperative": {
-      "base": "src/{{withFeature featureName}}/components{{withSub subName}}/_stories",
+      "base": "src/{{withFeature featureName}}/components{{withSubPath subPath}}/_stories",
       "excludes": ["core"],
       "files": [
         {

--- a/cli-assets/templates/reducers.ts.handlebars
+++ b/cli-assets/templates/reducers.ts.handlebars
@@ -2,5 +2,5 @@ import { combineReducers } from 'redux';
 import { {{fullName}}Slice } from './stores';
 
 export const {{featureName}}Reducer = combineReducers({
-  {{subName}}: {{fullName}}Slice.reducer,
+  {{firstSubName}}: {{fullName}}Slice.reducer,
 });

--- a/cli-assets/templates/store-index.ts.handlebars
+++ b/cli-assets/templates/store-index.ts.handlebars
@@ -1,1 +1,1 @@
-export * from './{{subName}}';
+export * from './{{firstSubName}}';

--- a/cli-assets/templates/store-sub-selector.ts.handlebars
+++ b/cli-assets/templates/store-sub-selector.ts.handlebars
@@ -1,7 +1,7 @@
 import { createSelector, createDraftSafeSelector } from '@reduxjs/toolkit';
 import { RootState } from '@common/store';
 
-const sel{{fullNameAsPascalCase}} = (state: RootState) => state.{{featureName}}.{{subName}};
+const sel{{fullNameAsPascalCase}} = (state: RootState) => state.{{featureName}}.{{firstSubName}};
 
 export const sel{{fullNameAsPascalCase}}Loading = createSelector(
   sel{{fullNameAsPascalCase}},

--- a/cli-test.sh
+++ b/cli-test.sh
@@ -1,4 +1,5 @@
 npm run build
+npm run clean:src
 node bin feat lookpin theson
 node bin ui sonicBoom/greenHill GreenHillZoneView
 node bin ui sonicBoom SonicRootView
@@ -6,3 +7,8 @@ node bin sb ./src/common/components/tailsAdv/EmeraldHillZoneView.tsx
 node bin sb ./src/common/components/RootDefaultLayout.tsx
 node bin sb ./src/features/sonic/components/tailsAdv/EmeraldHillZoneView.tsx imperative
 node bin sb ./src/features/sonic/components/RootDefaultLayout.tsx memo
+node bin ui ./src/ui/components/design/system/tag/someSome BaseTag memo
+node bin ui ./src/ui/components/design/system/tag/someSome OtherTag
+node bin ui ./src/ui/components/design ItsMyLifeMusicView imperative
+node bin ui ./src/ui/components/design/system/ OhMyLookpinForm imperative
+node bin ui ./src/ui/components/lookpin LookpinView

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CLI tool for front-end develop with jordy library",
   "main": "./build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "CLI tool for front-end develop with jordy library",
   "main": "./build/index.js",
   "scripts": {
-    "clean": "rimraf  build",
+    "clean": "rimraf build",
     "bundle": "esbuild packages/index.ts --bundle --platform=node --outfile=build/index.js",
     "build": "npm-run-all clean bundle",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "prettier": "prettier './packages/**/*.ts'",
     "lint": "eslint 'packages/**'",
+    "clean:src": "rimraf src",
     "test:cli": "sh ./cli-test.sh"
   },
   "bin": {

--- a/packages/code-generator/CodeFileWriter.test.ts
+++ b/packages/code-generator/CodeFileWriter.test.ts
@@ -24,7 +24,7 @@ function createMockFn() {
   }) as TemplateCompiler);
 
   const read = vi.fn((async () => {
-    const result = '{{featureName}}.{{subName}}';
+    const result = '{{featureName}}.{{firstSubName}}';
 
     return result;
   }) as TextFileReaderFn);
@@ -59,7 +59,7 @@ function createMockFn() {
 }
 
 describe('CodeFileWriterService', () => {
-  describe('지정된 템플릿 경로로 템플릿을 가져오고 데이터를 삽입할 수 있다.', async () => {
+  describe.only('지정된 템플릿 경로로 템플릿을 가져오고 데이터를 삽입할 수 있다.', async () => {
     const { read, compile, write, append, appendLogic, mkdir } = createMockFn();
     const service = new CodeFileWriterService(
       read,
@@ -72,9 +72,9 @@ describe('CodeFileWriterService', () => {
     const fileInfo = getFileInfo();
     const result = await service.makeAll(config, fileInfo);
 
-    const sampleSourceCode = `${fileInfo.featureName}.${fileInfo.subName}`;
-    const samplePath0 = `src/features/${fileInfo.featureName}/${fileInfo.subName}/${fileInfo.fileName}Awesome.tsx`;
-    const samplePath1 = `src/features/${fileInfo.featureName}/${fileInfo.subName}/${fileInfo.fileName}.tsx`;
+    const sampleSourceCode = `${fileInfo.featureName}.${fileInfo.firstSubName}`;
+    const samplePath0 = `src/features/${fileInfo.featureName}/${fileInfo.subPath}/${fileInfo.fileName}Awesome.tsx`;
+    const samplePath1 = `src/features/${fileInfo.featureName}/${fileInfo.subPath}/${fileInfo.fileName}.tsx`;
 
     afterAll(() => {
       compile.mockClear();
@@ -95,7 +95,7 @@ describe('CodeFileWriterService', () => {
       expect(read).toBeCalledWith(config.files[1].template);
     });
 
-    it('설정된 템플릿 정보만큼 컴파일한다.', () => {
+    it('설정된 템플릿 정보만큼 컴파일한다.', async () => {
       expect(compile).toBeCalledTimes(config.files.length * 2);
       expect(compile).toHaveReturnedWith(sampleSourceCode);
       expect(compile).toHaveReturnedWith(samplePath0);
@@ -121,9 +121,9 @@ describe('CodeFileWriterService', () => {
     const fileInfo = getSharedModuleInfo();
     const result = await service.makeAll(config, fileInfo);
 
-    const sampleSourceCode = `${fileInfo.featureName}.${fileInfo.subName}`;
-    const samplePath0 = `src/${fileInfo.featureName}/${fileInfo.subName}/${fileInfo.fileName}Awesome.tsx`;
-    const samplePath1 = `src/${fileInfo.featureName}/${fileInfo.subName}/${fileInfo.fileName}.tsx`;
+    const sampleSourceCode = `${fileInfo.featureName}.${fileInfo.firstSubName}`;
+    const samplePath0 = `src/${fileInfo.featureName}/${fileInfo.subPath}/${fileInfo.fileName}Awesome.tsx`;
+    const samplePath1 = `src/${fileInfo.featureName}/${fileInfo.subPath}/${fileInfo.fileName}.tsx`;
 
     afterAll(() => {
       compile.mockClear();
@@ -266,7 +266,7 @@ describe('CodeFileWriterService', () => {
       expect(result).toBe(1);
       expect(write).toBeCalledWith(
         `${config.base}/some/already/exists/${fileInfo.fileName}.ts`,
-        `${fileInfo.featureName}.${fileInfo.subName}`,
+        `${fileInfo.featureName}.${fileInfo.firstSubName}`,
         true
       );
       expect(append).not.toBeCalled();
@@ -278,7 +278,7 @@ describe('CodeFileWriterService', () => {
       expect(result).toBe(1);
       expect(write).toBeCalledWith(
         `${config.base}/any/already/exists/${fileInfo.fullName}.ts`,
-        `${fileInfo.featureName}.${fileInfo.subName}`,
+        `${fileInfo.featureName}.${fileInfo.firstSubName}`,
         false
       );
       expect(append).toBeCalled();
@@ -290,7 +290,7 @@ describe('CodeFileWriterService', () => {
 
       expect(write).toBeCalledWith(
         `${config.base}/any/already/exists/${fileInfo.fullName}.ts`,
-        `${fileInfo.featureName}.${fileInfo.subName}`,
+        `${fileInfo.featureName}.${fileInfo.firstSubName}`,
         false
       );
       expect(append).toBeCalled();
@@ -350,7 +350,7 @@ describe('CodeFileWriterService', () => {
       );
       expect(mkdir).toBeCalledWith(`someSrcPath/${fileInfo.featureName}/pages`);
       expect(mkdir).toBeCalledWith(
-        `someSrcPath/${fileInfo.featureName}/some/${fileInfo.subName}/elements`
+        `someSrcPath/${fileInfo.featureName}/some/${fileInfo.subPath}/elements`
       );
     });
   });

--- a/packages/code-generator/FeatureFileInfo.ts
+++ b/packages/code-generator/FeatureFileInfo.ts
@@ -22,13 +22,37 @@ export class FeatureFileInfo implements FeatureFileInfoDto {
   get fullNameAsPascalCase() {
     return this.config.fullNameAsPascalCase;
   }
+
+  private _storybookTitle: string;
   get storybookTitle() {
-    return this.subName
-      ? `${this.featureName}/${this.subName}`
-      : this.featureName;
+    if (!this._storybookTitle) {
+      this._storybookTitle =
+        Array.isArray(this.subNames) && this.subNames.length > 0
+          ? `${this.featureName}/${this.subNames.join('/')}`
+          : this.featureName;
+    }
+
+    return this._storybookTitle;
   }
-  get subName() {
-    return this.config.subName;
+
+  get subNames() {
+    return this.config.subNames;
+  }
+
+  private _subPath: string;
+  get subPath() {
+    if (!this._subPath) {
+      this._subPath = this.subNames.join('/');
+    }
+
+    return this._subPath;
+  }
+
+  get firstSubName() {
+    if (this.subNames.length > 0) {
+      return this.subNames[0];
+    }
+    return '';
   }
 
   get fileName() {
@@ -89,7 +113,9 @@ export class FeatureFileInfo implements FeatureFileInfoDto {
       storybookTitle: this.storybookTitle,
       featureName: this.featureName,
       featureNameAsPascalCase: this.featureNameAsPascalCase,
-      subName: this.subName,
+      subNames: this.subNames,
+      subPath: this.subPath,
+      firstSubName: this.firstSubName,
     };
     return result;
   }

--- a/packages/code-generator/FeatureNameInfo.test.ts
+++ b/packages/code-generator/FeatureNameInfo.test.ts
@@ -1,8 +1,8 @@
-import { createFeatureNameConfig } from './FeatureNameInfo';
+import { createFeatureNameInfo } from './FeatureNameInfo';
 
-describe('FeatureNameConfig', () => {
+describe('FeatureNameInfo', () => {
   describe('feature 와 sub 명칭을 함께 설정', () => {
-    const config = createFeatureNameConfig('myPhone', 'blockThing');
+    const config = createFeatureNameInfo('myPhone', ['blockThing']);
 
     it('feature name 은 camelCase 이다.', () => {
       expect(config.featureName).toBe('myPhone');
@@ -13,7 +13,7 @@ describe('FeatureNameConfig', () => {
     });
 
     it('sub name 은 camelCase 이다.', () => {
-      expect(config.subName).toBe('blockThing');
+      expect(config.subNames).toEqual(['blockThing']);
     });
 
     it('full name 은 feature name 과 sub name 이 합쳐진 것이며 camelCase 이다.', () => {
@@ -29,8 +29,12 @@ describe('FeatureNameConfig', () => {
     });
   });
 
-  describe('feature 명칭만 설정', () => {
-    const config = createFeatureNameConfig('myPhone');
+  describe('feature 와 sub 명칭 여러개를 함께 설정', () => {
+    const config = createFeatureNameInfo('myPhone', [
+      'blockThing',
+      'anyThing',
+      'someThing',
+    ]);
 
     it('feature name 은 camelCase 이다.', () => {
       expect(config.featureName).toBe('myPhone');
@@ -40,8 +44,40 @@ describe('FeatureNameConfig', () => {
       expect(config.featureNameAsPascalCase).toBe('MyPhone');
     });
 
-    it('sub name 은 빈 값이다.', () => {
-      expect(config.subName).toBe('');
+    it('sub name 은 camelCase 이다.', () => {
+      expect(config.subNames).toEqual(['blockThing', 'anyThing', 'someThing']);
+    });
+
+    it('full name 은 feature name 과 sub name 이 합쳐진 것이며 camelCase 이다.', () => {
+      expect(config.fullName).toBe('myPhoneBlockThingAnyThingSomeThing');
+    });
+
+    it('full name 을 PascalCase 로 가져올 수 있다.', () => {
+      expect(config.fullNameAsPascalCase).toBe(
+        'MyPhoneBlockThingAnyThingSomeThing'
+      );
+    });
+
+    it('storybook title 은 feature 와 sub 사이에 슬래시(/)가 포함된다.', () => {
+      expect(config.storybookTitle).toBe(
+        'myPhone/blockThing/anyThing/someThing'
+      );
+    });
+  });
+
+  describe('feature 명칭만 설정', () => {
+    const config = createFeatureNameInfo('myPhone');
+
+    it('feature name 은 camelCase 이다.', () => {
+      expect(config.featureName).toBe('myPhone');
+    });
+
+    it('feature name 을 PascalCase 로 가져올 수 있다.', () => {
+      expect(config.featureNameAsPascalCase).toBe('MyPhone');
+    });
+
+    it('sub name 은 빈 배열이다.', () => {
+      expect(config.subNames).toEqual([]);
     });
 
     it('full name 은 feature name 의 camelCase 이다.', () => {

--- a/packages/code-generator/FeatureNameInfo.ts
+++ b/packages/code-generator/FeatureNameInfo.ts
@@ -6,6 +6,8 @@ export class FeatureNameInfo implements FeatureNameInfoDto {
   private _fullNameAsPascalCase: string;
   private _fullName: string;
   private _storybookTitle: string;
+  private _subPath = '';
+  private _firstSubName = '';
 
   get featureNameAsPascalCase() {
     return this._featureNameAsPascalCase;
@@ -19,17 +21,30 @@ export class FeatureNameInfo implements FeatureNameInfoDto {
   get storybookTitle() {
     return this._storybookTitle;
   }
+  public get subPath(): string {
+    return this._subPath;
+  }
+  public get firstSubName(): string {
+    return this._firstSubName;
+  }
 
   constructor(
     public readonly featureName: string,
-    public readonly subName: string = ''
+    public readonly subNames: string[] = []
   ) {
-    const subNameAsPascalCase = toCapitalize(subName);
+    const subNameAsPascalCase = toCapitalize(subNames);
 
     this._featureNameAsPascalCase = toCapitalize(featureName);
     this._fullNameAsPascalCase = `${this._featureNameAsPascalCase}${subNameAsPascalCase}`;
     this._fullName = `${featureName}${subNameAsPascalCase}`;
-    this._storybookTitle = subName ? `${featureName}/${subName}` : featureName;
+    this._storybookTitle = featureName;
+
+    if (Array.isArray(subNames) && subNames.length > 0) {
+      this._subPath = subNames.join('/');
+      this._firstSubName = subNames[0];
+
+      this._storybookTitle = `${featureName}/${this._subPath}`;
+    }
   }
 
   toPlainObject(): FeatureNameInfoDto {
@@ -39,16 +54,18 @@ export class FeatureNameInfo implements FeatureNameInfoDto {
       fullName: this.fullName,
       fullNameAsPascalCase: this.fullNameAsPascalCase,
       storybookTitle: this.storybookTitle,
-      subName: this.subName,
+      subNames: this.subNames,
+      subPath: this.subPath,
+      firstSubName: this.firstSubName,
     };
 
     return result;
   }
 }
 
-export function createFeatureNameConfig(
+export function createFeatureNameInfo(
   featureName: string,
-  subName?: string
+  subName?: string[]
 ): FeatureNameInfoDto {
   return new FeatureNameInfo(featureName, subName).toPlainObject();
 }

--- a/packages/code-generator/TypeScriptFilePathParser.test.ts
+++ b/packages/code-generator/TypeScriptFilePathParser.test.ts
@@ -1,3 +1,4 @@
+import { FeatureFileInfoDto } from './types';
 import { TypeScriptFilePathParser } from './TypeScriptFilePathParser';
 
 describe('TypeScriptFilePathParser', () => {
@@ -54,26 +55,119 @@ describe('TypeScriptFilePathParser', () => {
     });
   });
 
-  describe('findSubNameFrom', () => {
-    function findSubNameFrom(value: string): string {
-      return new TypeScriptFilePathParser().findSubNameFrom(value.split('/'));
+  describe('findSubNamesBySubLayer', () => {
+    function findSubNamesBySubLayer(subLayer: string, splittedPath: string[]) {
+      return new TypeScriptFilePathParser().findSubNamesBySubLayer(
+        subLayer,
+        splittedPath
+      );
     }
 
-    it('분할된 경로에서 sub name 을 추출한다.', () => {
-      const result = findSubNameFrom(normalPath);
+    it.each([
+      [
+        '분할된 경로에서 하위명칭을 추출한다.',
+        'components',
+        '/home/works/jordy-prj/src/features/jordy/components/haha/hoho/kaka/koko/WhatView.tsx',
+        ['haha', 'hoho', 'kaka', 'koko'],
+      ],
+      [
+        '분할된 경로가 상대경로여도 의도대로 추출한다.',
+        'components',
+        './src/features/jordy/components/haha/hoho/kaka/koko/WhatView.tsx',
+        ['haha', 'hoho', 'kaka', 'koko'],
+      ],
+      [
+        '경로가 서브계층 루트라면 빈 값을 내보낸다.',
+        'components',
+        './src/features/jordy/components',
+        [],
+      ],
+      [
+        '하위 경로가 하나밖에 없다면 그 값만 내보낸다.',
+        'components',
+        './src/features/jordy/components/lookpinApp',
+        ['lookpinApp'],
+      ],
+      [
+        '하위 경로가 하나뿐이고 끝에 슬래시가 있어도 의도대로 동작된다.',
+        'components',
+        './src/features/jordy/components/lookpinApp/',
+        ['lookpinApp'],
+      ],
+      [
+        '경로가 서브계층 루트인데 끝에 슬래시가 있어도 빈 값을 내보낸다.',
+        'components',
+        './src/features/jordy/components/',
+        [],
+      ],
+      [
+        '경로가 서브계층 루트일 때 하위 파일이 있어도 빈 값을 내보낸다.',
+        'components',
+        './src/features/jordy/components/WhatView.tsx',
+        [],
+      ],
+      [
+        '분할된 경로가 서브계층에 속하지 않는다면 빈 값을 내보낸다.',
+        'containers',
+        './src/features/jordy/components/haha/hoho/kaka/koko/WhatView.tsx',
+        [],
+      ],
+      [
+        '분할된 경로가 분석 불가능한 경로라면 빈 값을 내보낸다.',
+        'containers',
+        '/home/myFolder/features/jordy',
+        [],
+      ],
+      [
+        '디자인 시스템 경로여도 정상적으로 동작된다.',
+        'components',
+        './src/ui/components/materials/tags/BaseTag.tsx',
+        ['materials', 'tags'],
+      ],
+      [
+        '디자인 시스템 하위 모듈이 1개여도 정상적으로 동작된다.',
+        'components',
+        './src/ui/components/materials',
+        ['materials'],
+      ],
+      [
+        '디자인 시스템 루트 경로는 빈 값을 내보낸다.',
+        'components',
+        './src/ui/components',
+        [],
+      ],
+    ])('%s', (_, subLayer, path, expects) => {
+      const { subNames } = findSubNamesBySubLayer(subLayer, path.split('/'));
 
-      expect(result).toBe('boomSeries');
+      expect(subNames).toEqual(expects);
     });
+  });
 
-    it('상대 경로를 주어도 정상적으로 추출 가능하다.', () => {
-      const result = findSubNameFrom(relativePath);
+  describe('findSubNamesFrom', () => {
+    function findSubNamesFrom(value: string) {
+      return new TypeScriptFilePathParser().findSubNamesFrom(value.split('/'));
+    }
 
-      expect(result).toBe('rainCloud');
+    it.each([
+      [
+        '분할된 경로에서 sub name 을 추출한다.', //
+        normalPath,
+        ['boomSeries'],
+      ],
+      [
+        '상대 경로를 주어도 정상적으로 추출 가능하다.',
+        relativePath,
+        ['rainCloud'],
+      ],
+    ])('%s', (_, path, expects) => {
+      const result = findSubNamesFrom(path);
+
+      expect(result).toEqual(expects);
     });
 
     it('sub name 을 추출할 수 없으면 에러를 일으킨다.', () => {
       expect(() =>
-        findSubNameFrom('/root/work/src/features/stores/nya.wtf.ts')
+        findSubNamesFrom('/root/work/src/features/stores/nya.wtf.ts')
       ).toThrowError();
     });
   });
@@ -81,39 +175,126 @@ describe('TypeScriptFilePathParser', () => {
   describe('parse', () => {
     const parser = new TypeScriptFilePathParser();
 
-    it('주어진 경로값을 분석하여 객체로 만든다.', () => {
-      const result = parser.parse(
-        '/home/theson/lookpin-prj/src/features/sonic/stores/boomSeries/sonicBoomSeries.effect.ts'
-      );
+    describe('인자: 1개', () => {
+      it.each([
+        [
+          '주어진 경로값을 분석하여 객체로 만든다.',
+          '/home/theson/lookpin-prj/src/features/sonic/stores/boomSeries/sonicBoomSeries.effect.ts',
+          {
+            fullName: 'sonicBoomSeries',
+            fullNameAsPascalCase: 'SonicBoomSeries',
+            storybookTitle: 'sonic/boomSeries',
+            featureName: 'sonic',
+            featureNameAsPascalCase: 'Sonic',
+            subNames: ['boomSeries'],
+            subPath: 'boomSeries',
+            firstSubName: 'boomSeries',
+            fileName: 'sonicBoomSeries.effect',
+            fileExt: 'ts',
+            fileNameAsPascalCase: 'SonicBoomSeriesEffect',
+          },
+        ],
+        [
+          '경로에 파일이 없을 경우, 파일명과 확장자는 빈값이다.',
+          '/home/theson/lookpin-prj/src/features/sonic/stores/boomSeries',
+          {
+            fullName: 'sonicBoomSeries',
+            fullNameAsPascalCase: 'SonicBoomSeries',
+            storybookTitle: 'sonic/boomSeries',
+            featureName: 'sonic',
+            featureNameAsPascalCase: 'Sonic',
+            subNames: ['boomSeries'],
+            subPath: 'boomSeries',
+            firstSubName: 'boomSeries',
+            fileName: '',
+            fileExt: '',
+            fileNameAsPascalCase: '',
+          },
+        ],
+        [
+          '컴포넌트 경로에 sub name 이 포함 안되어있다면 sub name 은 빈값 취급된다.',
+          '/home/theson/lookpin-prj/src/features/sonic/components/GreenHillView.tsx',
+          {
+            fullName: 'sonic',
+            fullNameAsPascalCase: 'Sonic',
+            storybookTitle: 'sonic',
+            featureName: 'sonic',
+            featureNameAsPascalCase: 'Sonic',
+            subNames: [],
+            subPath: '',
+            firstSubName: '',
+            fileName: 'GreenHillView',
+            fileExt: 'tsx',
+            fileNameAsPascalCase: 'GreenHillView',
+          },
+        ],
+      ])('%s', (_, path, expects) => {
+        const result = parser.parse(path);
 
-      expect(result).toEqual({
-        fullName: 'sonicBoomSeries',
-        fullNameAsPascalCase: 'SonicBoomSeries',
-        storybookTitle: 'sonic/boomSeries',
-        featureName: 'sonic',
-        featureNameAsPascalCase: 'Sonic',
-        subName: 'boomSeries',
-        fileName: 'sonicBoomSeries.effect',
-        fileExt: 'ts',
-        fileNameAsPascalCase: 'SonicBoomSeriesEffect',
+        expect(result).toEqual(expects);
       });
     });
 
-    it('경로에 파일이 없을 경우, 파일명과 확장자는 빈값이다.', () => {
-      const result = parser.parse(
-        '/home/theson/lookpin-prj/src/features/sonic/stores/boomSeries'
-      );
+    describe('인자: 2개', () => {
+      it.each([
+        [
+          '두가지 인자값을 넣으면 첫번째를 main feature, 두번째를 sub feature 로 인식한다.',
+          'lookpin',
+          'search',
+          {
+            fullName: 'lookpinSearch',
+            fullNameAsPascalCase: 'LookpinSearch',
+            storybookTitle: 'lookpin/search',
+            featureName: 'lookpin',
+            featureNameAsPascalCase: 'Lookpin',
+            subNames: ['search'],
+            subPath: 'search',
+            firstSubName: 'search',
+            fileName: '',
+            fileExt: '',
+            fileNameAsPascalCase: '',
+          },
+        ],
+        [
+          '두가지 인자값을 넣었는데 두번째가 비었다면, sub feature 는 빈값으로 인식된다.',
+          'lookpin',
+          '',
+          {
+            fullName: 'lookpin',
+            fullNameAsPascalCase: 'Lookpin',
+            storybookTitle: 'lookpin',
+            featureName: 'lookpin',
+            featureNameAsPascalCase: 'Lookpin',
+            subNames: [],
+            subPath: '',
+            firstSubName: '',
+            fileName: '',
+            fileExt: '',
+            fileNameAsPascalCase: '',
+          },
+        ],
+        [
+          '두번째 인자가 문자열이 아니라면 sub feature 는 빈 값으로 인식된다.',
+          'lookpin',
+          undefined,
+          {
+            fullName: 'lookpin',
+            fullNameAsPascalCase: 'Lookpin',
+            storybookTitle: 'lookpin',
+            featureName: 'lookpin',
+            featureNameAsPascalCase: 'Lookpin',
+            subNames: [],
+            subPath: '',
+            firstSubName: '',
+            fileName: '',
+            fileExt: '',
+            fileNameAsPascalCase: '',
+          },
+        ],
+      ])('%s', (_, given1, given2, expects) => {
+        const result = parser.parse(given1, given2);
 
-      expect(result).toEqual({
-        fullName: 'sonicBoomSeries',
-        fullNameAsPascalCase: 'SonicBoomSeries',
-        storybookTitle: 'sonic/boomSeries',
-        featureName: 'sonic',
-        featureNameAsPascalCase: 'Sonic',
-        subName: 'boomSeries',
-        fileName: '',
-        fileExt: '',
-        fileNameAsPascalCase: '',
+        expect(result).toEqual(expects);
       });
     });
 
@@ -122,229 +303,296 @@ describe('TypeScriptFilePathParser', () => {
         parser.parse('/home/theson/lookpin-prj/src/features/sonic/stores')
       ).toThrowError();
     });
-
-    it('컴포넌트 경로에 sub name 이 포함 안되어있다면 sub name 은 빈값 취급된다.', () => {
-      const result = parser.parse(
-        '/home/theson/lookpin-prj/src/features/sonic/components/GreenHillView.tsx'
-      );
-
-      expect(result).toEqual({
-        fullName: 'sonic',
-        fullNameAsPascalCase: 'Sonic',
-        storybookTitle: 'sonic',
-        featureName: 'sonic',
-        featureNameAsPascalCase: 'Sonic',
-        subName: '',
-        fileName: 'GreenHillView',
-        fileExt: 'tsx',
-        fileNameAsPascalCase: 'GreenHillView',
-      });
-    });
-
-    it('두가지 인자값을 넣으면 첫번째를 main feature, 두번째를 sub feature 로 인식한다.', () => {
-      const result = parser.parse('lookpin', 'search');
-
-      expect(result).toEqual({
-        fullName: 'lookpinSearch',
-        fullNameAsPascalCase: 'LookpinSearch',
-        storybookTitle: 'lookpin/search',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: 'search',
-        fileName: '',
-        fileExt: '',
-        fileNameAsPascalCase: '',
-      });
-    });
-
-    it('두가지 인자값을 넣었는데 두번째가 비었다면, sub feature 를 basic 으로 자동 인식한다.', () => {
-      const result = parser.parse('lookpin', '');
-
-      expect(result).toEqual({
-        fullName: 'lookpinBasic',
-        fullNameAsPascalCase: 'LookpinBasic',
-        storybookTitle: 'lookpin/basic',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: 'basic',
-        fileName: '',
-        fileExt: '',
-        fileNameAsPascalCase: '',
-      });
-    });
-
-    it('두번째 인자가 문자열이 아니라면 sub feature 를 basic 으로 자동 인식한다.', () => {
-      const result = parser.parse('lookpin', undefined);
-
-      expect(result).toEqual({
-        fullName: 'lookpinBasic',
-        fullNameAsPascalCase: 'LookpinBasic',
-        storybookTitle: 'lookpin/basic',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: 'basic',
-        fileName: '',
-        fileExt: '',
-        fileNameAsPascalCase: '',
-      });
-    });
   });
 
   describe('parseForComponent', () => {
     const parser = new TypeScriptFilePathParser();
 
-    describe('모듈과 하위 모듈 명칭, 그리고 컴포넌트 명칭으로 분석된 결과를 만들수 있다.', () => {
-      it('하위 모듈 포함', () => {
-        const result = parser.parseForComponent(
-          'lookpin/search',
-          'SearchTable'
-        );
+    describe.each([
+      [
+        '모듈과 하위 모듈, 컴포넌트 명칭으로 분석된 결과를 만들수 있다.',
+        [
+          [
+            '하위 모듈 포함',
+            'lookpin/search',
+            'SearchTable',
+            {
+              fullName: 'lookpinSearch',
+              fullNameAsPascalCase: 'LookpinSearch',
+              storybookTitle: 'lookpin/search',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: ['search'],
+              subPath: 'search',
+              firstSubName: 'search',
+              fileName: 'SearchTable',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'SearchTable',
+            },
+          ],
+          [
+            '하위 모듈 없음',
+            'lookpin',
+            'SearchTable',
+            {
+              fullName: 'lookpin',
+              fullNameAsPascalCase: 'Lookpin',
+              storybookTitle: 'lookpin',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: [],
+              subPath: '',
+              firstSubName: '',
+              fileName: 'SearchTable',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'SearchTable',
+            },
+          ],
+        ],
+      ],
+      [
+        '실제 폴더 경로와 컴포넌트 명칭으로 의도대로 분석된다.',
+        [
+          [
+            '하위 경로 포함',
+            '/home/theson/work/myProject/src/features/lookpin/components/search',
+            'SearchTable',
+            {
+              fullName: 'lookpinSearch',
+              fullNameAsPascalCase: 'LookpinSearch',
+              storybookTitle: 'lookpin/search',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: ['search'],
+              subPath: 'search',
+              firstSubName: 'search',
+              fileName: 'SearchTable',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'SearchTable',
+            },
+          ],
+          [
+            '하위 경로 없음',
+            '/home/theson/work/myProject/src/features/lookpin/components',
+            'SearchTable',
+            {
+              fullName: 'lookpin',
+              fullNameAsPascalCase: 'Lookpin',
+              storybookTitle: 'lookpin',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: [],
+              subPath: '',
+              firstSubName: '',
+              fileName: 'SearchTable',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'SearchTable',
+            },
+          ],
+        ],
+        [
+          '상대 경로를 주어도 의도대로 분석된다.',
+          [
+            '하위경로 포함',
+            './src/features/lookpin/components/search',
+            'SearchTable',
+            {
+              fullName: 'lookpinSearch',
+              fullNameAsPascalCase: 'LookpinSearch',
+              storybookTitle: 'lookpin/search',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: ['search'],
+              subPath: 'search',
+              firstSubName: 'search',
+              fileName: 'SearchTable',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'SearchTable',
+            },
+          ],
+          [
+            '하위경로 없음',
+            './src/features/lookpin/components',
+            'SearchTable',
+            {
+              fullName: 'lookpin',
+              fullNameAsPascalCase: 'Lookpin',
+              storybookTitle: 'lookpin',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: [],
+              subPath: '',
+              firstSubName: '',
+              fileName: 'SearchTable',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'SearchTable',
+            },
+          ],
+        ],
+      ],
+      [
+        '기능 모듈 경로',
+        [
+          [
+            '절대경로',
+            '/home/mall/my/project/src/features/lookpin',
+            'OtherViewPanel',
+            {
+              fullName: 'lookpin',
+              fullNameAsPascalCase: 'Lookpin',
+              storybookTitle: 'lookpin',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: [],
+              subPath: '',
+              firstSubName: '',
+              fileName: 'OtherViewPanel',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'OtherViewPanel',
+            },
+          ],
+          [
+            '상대경로',
+            './src/features/lookpin',
+            'OtherViewPanel',
+            {
+              fullName: 'lookpin',
+              fullNameAsPascalCase: 'Lookpin',
+              storybookTitle: 'lookpin',
+              featureName: 'lookpin',
+              featureNameAsPascalCase: 'Lookpin',
+              subNames: [],
+              subPath: '',
+              firstSubName: '',
+              fileName: 'OtherViewPanel',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'OtherViewPanel',
+            },
+          ],
+        ],
+      ],
+      [
+        'UI 모듈 경로',
+        [
+          [
+            '절대경로 & 컴포넌트 루트',
+            '/c/works/gits/some-project/src/ui/components',
+            'DesignSystemView',
+            {
+              fullName: 'ui',
+              fullNameAsPascalCase: 'Ui',
+              storybookTitle: 'ui',
+              featureName: 'ui',
+              featureNameAsPascalCase: 'Ui',
+              subNames: [],
+              subPath: '',
+              firstSubName: '',
+              fileName: 'DesignSystemView',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'DesignSystemView',
+            },
+          ],
+          [
+            '절대경로 & 서브 경로',
+            '/c/works/gits/some-project/src/ui/components/views',
+            'DesignSystemView',
+            {
+              fullName: 'uiViews',
+              fullNameAsPascalCase: 'UiViews',
+              storybookTitle: 'ui/views',
+              featureName: 'ui',
+              featureNameAsPascalCase: 'Ui',
+              subNames: ['views'],
+              subPath: 'views',
+              firstSubName: 'views',
+              fileName: 'DesignSystemView',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'DesignSystemView',
+            },
+          ],
+          [
+            '절대경로 & 서브 경로 여러개',
+            '/c/works/gits/some-project/src/ui/components/search/forms/section',
+            'DesignSystemView',
+            {
+              fullName: 'uiSearchFormsSection',
+              fullNameAsPascalCase: 'UiSearchFormsSection',
+              storybookTitle: 'ui/search/forms/section',
+              featureName: 'ui',
+              featureNameAsPascalCase: 'Ui',
+              subNames: ['search', 'forms', 'section'],
+              subPath: 'search/forms/section',
+              firstSubName: 'search',
+              fileName: 'DesignSystemView',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'DesignSystemView',
+            },
+          ],
+          [
+            '상대경로 & 컴포넌트 루트',
+            './src/ui/components',
+            'DesignSystemView',
+            {
+              fullName: 'ui',
+              fullNameAsPascalCase: 'Ui',
+              storybookTitle: 'ui',
+              featureName: 'ui',
+              featureNameAsPascalCase: 'Ui',
+              subNames: [],
+              subPath: '',
+              firstSubName: '',
+              fileName: 'DesignSystemView',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'DesignSystemView',
+            },
+          ],
+          [
+            '상대경로 & 서브 경로',
+            './src/ui/components/views',
+            'DesignSystemView',
+            {
+              fullName: 'uiViews',
+              fullNameAsPascalCase: 'UiViews',
+              storybookTitle: 'ui/views',
+              featureName: 'ui',
+              featureNameAsPascalCase: 'Ui',
+              subNames: ['views'],
+              subPath: 'views',
+              firstSubName: 'views',
+              fileName: 'DesignSystemView',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'DesignSystemView',
+            },
+          ],
+          [
+            '상대경로 & 서브 경로 여러개',
+            './src/ui/components/search/forms/section',
+            'DesignSystemView',
+            {
+              fullName: 'uiSearchFormsSection',
+              fullNameAsPascalCase: 'UiSearchFormsSection',
+              storybookTitle: 'ui/search/forms/section',
+              featureName: 'ui',
+              featureNameAsPascalCase: 'Ui',
+              subNames: ['search', 'forms', 'section'],
+              subPath: 'search/forms/section',
+              firstSubName: 'search',
+              fileName: 'DesignSystemView',
+              fileExt: 'tsx',
+              fileNameAsPascalCase: 'DesignSystemView',
+            },
+          ],
+        ],
+      ],
+    ])('%s', (_, cases) => {
+      it.each(cases)(
+        '%s',
+        (_, given1: string, given2: string, expects: FeatureFileInfoDto) => {
+          const result = parser.parseForComponent(given1, given2);
 
-        expect(result).toEqual({
-          fullName: 'lookpinSearch',
-          fullNameAsPascalCase: 'LookpinSearch',
-          storybookTitle: 'lookpin/search',
-          featureName: 'lookpin',
-          featureNameAsPascalCase: 'Lookpin',
-          subName: 'search',
-          fileName: 'SearchTable',
-          fileExt: 'tsx',
-          fileNameAsPascalCase: 'SearchTable',
-        });
-      });
-      it('하위 모듈 없음', () => {
-        const result = parser.parseForComponent('lookpin', 'SearchTable');
-
-        expect(result).toEqual({
-          fullName: 'lookpin',
-          fullNameAsPascalCase: 'Lookpin',
-          storybookTitle: 'lookpin',
-          featureName: 'lookpin',
-          featureNameAsPascalCase: 'Lookpin',
-          subName: '',
-          fileName: 'SearchTable',
-          fileExt: 'tsx',
-          fileNameAsPascalCase: 'SearchTable',
-        });
-      });
-    });
-
-    describe('실제 폴더 경로와 컴포넌트 명칭으로 의도대로 분석된다.', () => {
-      it('하위 경로 포함', () => {
-        const result = parser.parseForComponent(
-          '/home/theson/work/myProject/src/features/lookpin/components/search',
-          'SearchTable'
-        );
-
-        expect(result).toEqual({
-          fullName: 'lookpinSearch',
-          fullNameAsPascalCase: 'LookpinSearch',
-          storybookTitle: 'lookpin/search',
-          featureName: 'lookpin',
-          featureNameAsPascalCase: 'Lookpin',
-          subName: 'search',
-          fileName: 'SearchTable',
-          fileExt: 'tsx',
-          fileNameAsPascalCase: 'SearchTable',
-        });
-      });
-
-      it('하위 경로 없음', () => {
-        const result = parser.parseForComponent(
-          '/home/theson/work/myProject/src/features/lookpin/components',
-          'SearchTable'
-        );
-
-        expect(result).toEqual({
-          fullName: 'lookpin',
-          fullNameAsPascalCase: 'Lookpin',
-          storybookTitle: 'lookpin',
-          featureName: 'lookpin',
-          featureNameAsPascalCase: 'Lookpin',
-          subName: '',
-          fileName: 'SearchTable',
-          fileExt: 'tsx',
-          fileNameAsPascalCase: 'SearchTable',
-        });
-      });
-    });
-
-    describe('상대 경로를 주어도 의도대로 분석된다.', () => {
-      it('하위경로 포함', () => {
-        const result = parser.parseForComponent(
-          './src/features/lookpin/components/search',
-          'SearchTable'
-        );
-
-        expect(result).toEqual({
-          fullName: 'lookpinSearch',
-          fullNameAsPascalCase: 'LookpinSearch',
-          storybookTitle: 'lookpin/search',
-          featureName: 'lookpin',
-          featureNameAsPascalCase: 'Lookpin',
-          subName: 'search',
-          fileName: 'SearchTable',
-          fileExt: 'tsx',
-          fileNameAsPascalCase: 'SearchTable',
-        });
-      });
-
-      it('하위경로 없음', () => {
-        const result = parser.parseForComponent(
-          './src/features/lookpin/components',
-          'SearchTable'
-        );
-
-        expect(result).toEqual({
-          fullName: 'lookpin',
-          fullNameAsPascalCase: 'Lookpin',
-          storybookTitle: 'lookpin',
-          featureName: 'lookpin',
-          featureNameAsPascalCase: 'Lookpin',
-          subName: '',
-          fileName: 'SearchTable',
-          fileExt: 'tsx',
-          fileNameAsPascalCase: 'SearchTable',
-        });
-      });
-    });
-
-    it('기능 모듈 경로를 주어도 의도대로 분석된다.', () => {
-      const result = parser.parseForComponent(
-        '/home/mall/my/project/src/features/lookpin',
-        'OtherViewPanel'
+          expect(result).toEqual(expects);
+        }
       );
-
-      expect(result).toEqual({
-        fullName: 'lookpin',
-        fullNameAsPascalCase: 'Lookpin',
-        storybookTitle: 'lookpin',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: '',
-        fileName: 'OtherViewPanel',
-        fileExt: 'tsx',
-        fileNameAsPascalCase: 'OtherViewPanel',
-      });
-    });
-
-    it('기능 모듈 경로를 상대 경로로 주어도 의도대로 분석된다.', () => {
-      const result = parser.parseForComponent(
-        './src/features/lookpin',
-        'OtherViewPanel'
-      );
-
-      expect(result).toEqual({
-        fullName: 'lookpin',
-        fullNameAsPascalCase: 'Lookpin',
-        storybookTitle: 'lookpin',
-        featureName: 'lookpin',
-        featureNameAsPascalCase: 'Lookpin',
-        subName: '',
-        fileName: 'OtherViewPanel',
-        fileExt: 'tsx',
-        fileNameAsPascalCase: 'OtherViewPanel',
-      });
     });
   });
 });

--- a/packages/code-generator/_fixtures/CodeFileWriter.fixtures.ts
+++ b/packages/code-generator/_fixtures/CodeFileWriter.fixtures.ts
@@ -6,7 +6,7 @@ function getConfig(
   childExcludes: string[] = []
 ) {
   const config: CodeGeneratorPathConfigDto = {
-    base: 'src/{{withFeature featureName}}/{{subName}}',
+    base: 'src/{{withFeature featureName}}/{{firstSubName}}',
     excludes: parentExcludes,
     files: [
       {
@@ -72,14 +72,17 @@ function getFileInfo() {
     fullNameAsPascalCase: 'LookpinBestShop',
     featureName: 'lookpin',
     featureNameAsPascalCase: 'Lookpin',
-    subName: 'bestShop',
+    subNames: ['bestShop'],
+    subPath: 'bestShop',
+    firstSubName: 'bestShop',
+    storybookTitle: '',
   };
   return fileInfo;
 }
 
 function getSharedModuleInfo(
   featureName = 'shared',
-  subName = 'memberInfo',
+  subNames = ['memberInfo'],
   fileName = 'SortableList.tsx'
 ) {
   const featureNameAsPascalCase = toCapitalize(featureName);
@@ -89,11 +92,14 @@ function getSharedModuleInfo(
     fileName: splittedFileName[0],
     fileExt: splittedFileName[1],
     fileNameAsPascalCase: splittedFileName[0],
-    fullName: `${featureName}${toCapitalize(subName)}`,
-    fullNameAsPascalCase: `${featureNameAsPascalCase}${toCapitalize(subName)}`,
+    fullName: `${featureName}${toCapitalize(subNames)}`,
+    fullNameAsPascalCase: `${featureNameAsPascalCase}${toCapitalize(subNames)}`,
     featureName,
     featureNameAsPascalCase,
-    subName,
+    subNames,
+    subPath: subNames.join('/'),
+    firstSubName: subNames[0],
+    storybookTitle: '',
   };
   return fileInfo;
 }
@@ -113,7 +119,7 @@ function getConfigForFolderTest() {
         folderName: 'pages',
       },
       {
-        folderName: 'some/{{subName}}/elements',
+        folderName: 'some/{{subPath}}/elements',
       },
     ],
   };

--- a/packages/code-generator/constants.ts
+++ b/packages/code-generator/constants.ts
@@ -1,2 +1,2 @@
 export const CLI_ASSETS_NAME = 'cli-assets';
-export const COMMON_FEATURE_NAMES = ['common', 'core', 'shared'] as const;
+export const COMMON_FEATURE_NAMES = ['common', 'core', 'shared', 'ui'] as const;

--- a/packages/code-generator/types.ts
+++ b/packages/code-generator/types.ts
@@ -16,7 +16,9 @@ export interface FeatureNameInfoDto {
   storybookTitle: string;
   featureName: string;
   featureNameAsPascalCase: string;
-  subName: string;
+  subNames: string[];
+  subPath: string;
+  firstSubName: string;
 }
 
 export interface SimpleFileInfoDto {

--- a/packages/code-generator/utils.ts
+++ b/packages/code-generator/utils.ts
@@ -8,11 +8,17 @@ Handlebars.registerHelper('withFeature', function (value) {
   return `${COMMON_FEATURE_NAMES.includes(value) ? '' : 'features/'}${value}`;
 });
 
-Handlebars.registerHelper('withSub', function (value) {
+Handlebars.registerHelper('withSubPath', function (value) {
+  if (Array.isArray(value)) {
+    return `/${value.join('/')}`;
+  }
   return value ? `/${value}` : '';
 });
 
-export function toCapitalize(value: string) {
+export function toCapitalize(value: string | string[]): string {
+  if (Array.isArray(value)) {
+    return value.map(toCapitalize).join('');
+  }
   if (!value || typeof value !== 'string' || value.length === 0) {
     return '';
   }


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- `src/ui` 와 같은 경로에 리액트 컴포넌트를 작성할 수 있도록 기능 수정합니다.
- 추가로 `components` 경로가 포함되어 있을 시, 하위 폴더 깊이에 제한없이 만들고 그 곳에 컴포넌트를 생성할 수 있도록 기능 개선하였습니다.

## Notes

모듈경로 분석 기능에 큰 변화가 있어서 이에 대한 테스트 코드를 수정하고 정리하느라 수정사항이 많아 보입니다.
그래도 같이 보는게 좋을 듯 하여 함께 포함 시켰으므로 이 점 참고 바랍니다~ 🙇‍♂️ 