### PR TITLE
Feat: 스토리북 템플릿을 v7.0 기반으로 변경, vscode 스니펫 파일 복사 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bak
 .DS_Store
+.vscode
 node_modules
 /cjs
 /esm5

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ $ npm install jordy-cli
 ```sh
 npm run cli feat lookpin userQuestion
 ```
+
+아래는 vscode 에서 쓰이는 공용 스니펫(snippets)을 복사합니다.
+
+```sh
+npm run cli snippets
+```

--- a/cli-assets/snippets/typescript.code-snippets
+++ b/cli-assets/snippets/typescript.code-snippets
@@ -1,0 +1,255 @@
+{
+  
+  "Generate Single Selector": {
+    "prefix": "!selsingle",
+    "description": "단일 셀렉터를 만든다.",
+    "body": [
+      "export const sel${TM_FILENAME_BASE/(.*)\\.selector/${1:/capitalize}/g}${2:WhatState} = createSelector(",
+      "  sel${TM_FILENAME_BASE/(.*)\\.selector/${1:/capitalize}/g},",
+      "  state => {",
+      "    return state${0:.someField};",
+      "  }",
+      ");"
+    ]
+  },
+  "Generate Single Draft Selector": {
+    "prefix": "!seldrfsingle",
+    "description": "단일 드래프트 셀렉터를 만든다. - 액션이나 이팩트에서 상태값을 셀렉팅 할 때 쓰인다.",
+    "body": [
+      "export const drf${TM_FILENAME_BASE/(.*)\\.selector/${1:/capitalize}/g}${2:WhatState} = createDraftSafeSelector${3}(",
+      "  sel${TM_FILENAME_BASE/(.*)\\.selector/${1:/capitalize}/g},",
+      "  state => {",
+      "    return state${0:.someField};",
+      "  }",
+      ");"
+    ]
+  },
+  
+  "Generate Redux Toolkit - Single Effect": {
+    "prefix": "!effsingle",
+    "description": "단일 이펙트 함수를 만든다.",
+    "body": [
+      "export const eff${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2:WhatAction} = createAsyncThunk(",
+      "  '${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2}',",
+      "  async () => {",
+      "    const result = await repo${10:.fetchSomeMethod};",
+      "",
+      "    return result;",
+      "  }",
+      ");"
+    ]
+  },
+  "Generate Redux Toolkit - Single Effect With Redux Api": {
+    "prefix": "!effsingleapi",
+    "description": "단일 이펙트 함수를 만든다. Redux Api 가 포함되어 있다.",
+    "body": [
+      "export const eff${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2:WhatAction} = createAsyncThunk<",
+      "  ${3:ReturnType},",
+      "  ${4:PayloadType},",
+      "  { state: RootState }",
+      ">(",
+      "  '${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2}',",
+      "  async (payload, { getState, dispatch }) => {",
+      "    const result = await repo${10:.fetchSomeMethod};",
+      "",
+      "    return result;",
+      "  }",
+      ");"
+    ]
+  },
+  "Generate Redux Toolkit - Single Effect With Redux Full Api": {
+    "prefix": "!effsingleapifull",
+    "description": "단일 이펙트 함수를 만든다. 모든 Redux Api 가 포함되어 있다.",
+    "body": [
+      "export const eff${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2:WhatAction} = createAsyncThunk<",
+      "  ${3:ReturnType},",
+      "  ${4:PayloadType},",
+      "  { state: RootState, rejectValue: MyRejectType }",
+      ">(",
+      "  '${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2}',",
+      "  async (payload, { getState, dispatch, rejectWithValue, signal, requestId }) => {",
+      "    const result = await repo${10:.fetchSomeMethod};",
+      "",
+      "    return result;",
+      "  }",
+      ");"
+    ]
+  },
+  "Generate Redux Toolkit - Single Normal Action": {
+    "prefix": "!actsingle",
+    "description": "동기식 액션 하나를 만든다.",
+    "body": [
+      "export const act${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2:WhatAction} = createAction<${3:PayloadType}>(",
+      "  '${TM_FILENAME_BASE/(.*)\\.effect/${1:/capitalize}/g}${2}',",
+      ");"
+    ]
+  },
+  
+  "Generate Redux Toolkit - Single Action Reducer": {
+    "prefix": "!sliceaction",
+    "description": "슬라이스 내 액션 리듀서 하나를 만든다.",
+    "body": [
+      "${1:doSomething}(state, { payload }: PayloadAction<$0>) {",
+      "  ",
+      "},"
+    ]
+  },
+  "Generate Redux Toolkit - Multi Async Action Reducer": {
+    "prefix": "!sliceaddcases",
+    "description": "슬라이스 내 비동기 액션 리듀서 3종류를 만든다.",
+    "body": [
+      ".addCase(${1:effAsyncAction}.pending, (state, { meta }) => {",
+      "  state.loading = true;",
+      "})",
+      ".addCase(${1:effAsyncAction}.rejected, (state, { payload, error }) => {",
+      "  state.loading = false;",
+      "})",
+      ".addCase(${1:effAsyncAction}.fulfilled, (state, { payload }) => {",
+      "  state.loading = false;",
+      "  ${0}",
+      "})"
+    ]
+  },
+  "Generate Redux Toolkit - Single Async Action Reducer": {
+    "prefix": "!sliceaddcase",
+    "description": "슬라이스 내 비동기 액션 리듀서 1개를 만든다.",
+    "body": [
+      ".addCase(${1:effAsyncAction}.${2|pending,fulfilled,rejected|}, (state, { meta, payload }) => {",
+      "  ${0}",
+      "})",
+    ]
+  },
+  "Generate Reducer File": {
+    "prefix": "!reducersfile",
+    "description": "기능 모듈의 리듀서 파일을 만든다.",
+    "body": [
+      "import { combineReducers } from 'redux';",
+      "import {",
+      "  ${TM_DIRECTORY/^.+\\/(.*)$/$1/}${1/(.*)/${0:/capitalize}/}Slice,",
+      "} from './stores';",
+      "",
+      "export const ${TM_DIRECTORY/^.+\\/(.*)$/$1/}Reducer = combineReducers({",
+      "  ${1:name}: ${TM_DIRECTORY/^.+\\/(.*)$/$1/}${1/(.*)/${0:/capitalize}/}Slice.reducer,",
+      "});",
+    ]
+  },
+  "Add Single Reducer": {
+    "prefix": "!reducer",
+    "description": "기능 모듈의 리듀서 하나를 추가한다.",
+    "body": [
+      "${1:name}: ${TM_DIRECTORY/^.+\\/(.*)$/$1/}${1/(.*)/${0:/capitalize}/}Slice${0}.reducer,",
+    ]
+  },
+  "Generate Route File": {
+    "prefix": "!routes",
+    "description": "기능 모듈의 라우트 파일을 만든다.",
+    "body": [
+      "import React from 'react';",
+      "import { RouteObject } from 'react-router-dom';",
+      "",
+      "const ${1:CompPage} = React.lazy(() => import('./pages/${1}'));",
+      "",
+      "export const ${2:techBook}Routes: RouteObject[] = [",
+      "  {",
+      "    path: '/${2}',",
+      "    Component: ${1},",
+      "  }",
+      "];"
+    ]
+  },
+  "Generate Create Function": {
+    "prefix": "!createdto",
+    "description": "특정 타입에 대한 팩토리 함수를 만든다.",
+    "body": [
+      "export function create${1:SomeDto}() {",
+      "  const ${0}result: ${1}${2} = {",
+      "  ",
+      "  };",
+      "  return result;",
+      "}",
+    ]
+  },
+  "Generate Convert Function": {
+    "prefix": "!convertdto",
+    "description": "특정 타입에 대한 변환 함수를 만든다.",
+    "body": [
+      "export function to${1:SomeDto}(${2|entity,params,model,item,payload,args,dto,data|}: ChangePlease) {",
+      "  const ${0}result: ${1}${3} = {",
+      "  ",
+      "  };",
+      "  return result;",
+      "}",
+    ]
+  },
+  "Generate Refine Function": {
+    "prefix": "!refinedto",
+    "description": "특정 타입에 대한 정제 함수를 만든다.",
+    "body": [
+      "export function refine${1:SomeDto}(${2|data,origin,raw,queries|}: ${1}) {",
+      "  const ${0}result: ${1}${4} = {",
+      "  ",
+      "  };",
+      "  return result;",
+      "}",
+    ]
+  },
+  "Generate React Context File": {
+    "prefix": "!ctxfile",
+    "description": "간단한 컨텍스트 파일을 만든다.",
+    "body": [
+      "import { createContext, useContext } from 'react';",
+      "",
+      "const ${TM_FILENAME_BASE/(.*)\\.context/${1:/capitalize}/g}Context = createContext(",
+      ");",
+      "",
+      "export const ${TM_FILENAME_BASE/(.*)\\.context/${1:/capitalize}/g}CtxProvider = ${TM_FILENAME_BASE/(.*)\\.context/${1:/capitalize}/g}Context.Provider;",
+      "",
+      "export function use${TM_FILENAME_BASE/(.*)\\.context/${1:/capitalize}/g}Ctx() {",
+      "  const value = useContext(${TM_FILENAME_BASE/(.*)\\.context/${1:/capitalize}/g}Context);",
+      "",
+      "  return value;",
+      "}",
+      ""
+    ]
+  },
+  "Generate Query Hooks": {
+    "prefix": "!queryhooks",
+    "description": "자체 캐싱 기능을 가지는 쿼리 훅스를 만든다.",
+    "body": [
+      "import { createQuery } from '@common/createQuery';",
+      "import repo from '@core/repo';",
+      "",
+      "export const ${TM_FILENAME_BASE} = createQuery<ResultModel, Payload>({",
+      "  fetcher: repo.some.fetch,",
+      "  key: '${TM_FILENAME_BASE/(.*)use/${1:/capitalize}/g}',",
+      "  subKeysFromParams: [] as (keyof ResultModel)[],",
+      "  cache: 'session',",
+      "  expired: 60,",
+      "  defaultData: null,",
+      "  parameterConverter: (params) => {",
+      "  },",
+      "  resultConverter: (result) => {",
+      "  },",
+      "});",
+      ""
+    ]
+  },
+  "Generate Entity Template": {
+    "prefix": "!entity",
+    "description": "파일명 기반의 간단한 엔티티 껍데기 만들기.",
+    "body": [
+      "export interface ${TM_FILENAME_BASE/(.*)\\.entity/${1:/capitalize}/g}${2}${3|Entity,Params,Dto|} {",
+      "  ${0}",
+      "}"
+    ]
+  },
+  "Generate Model Template": {
+    "prefix": "!model",
+    "description": "파일명 기반의 간단한 모델 껍데기 만들기.",
+    "body": [
+      "export interface ${TM_FILENAME_BASE/(.*)\\.model/${1:/capitalize}/g}${2}${3|Model,ParamsModel,Payload,Dto|} {",
+      "  ${0}",
+      "}"
+    ]
+  },
+}

--- a/cli-assets/snippets/typescriptreact.code-snippets
+++ b/cli-assets/snippets/typescriptreact.code-snippets
@@ -1,0 +1,173 @@
+{
+  // Place your snippets for typescriptreact here. Each snippet is defined under a snippet name and has a prefix, body and
+  // description. The prefix is what is used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. Placeholders with the
+  // same ids are connected.
+  // Example:
+  // "Print to console": {
+  // 	"prefix": "log",
+  // 	"body": [
+  // 		"console.log('$1');",
+  // 		"$2"
+  // 	],
+  // 	"description": "Log output to console"
+  // }
+  "Event for Click": {
+    "prefix": "!hdlclick",
+    "description": "클릭 이벤트에 대한 핸들러를 만든다.",
+    "body": [
+      "const handle${1:Click}: React.MouseEventHandler<${2|HTMLButtonElement,HTMLInputElement,HTMLElement|}> = (e) => {",
+      "  ${10}",
+      "}"
+    ]
+  },
+  "Event for Change": {
+    "prefix": "!hdlchange",
+    "description": "변경 이벤트에 대한 핸들러를 만든다.",
+    "body": [
+      "const handle${1:Change}: React.ChangeEventHandler<${2|HTMLInputElement,HTMLTextAreaElement,HTMLElement|}> = (e) => {",
+      "  ${10}",
+      "}"
+    ]
+  },
+ 
+  "React Use State Hooks": {
+    "prefix": "!usestate",
+    "description": "useState 훅스를 만든다.",
+    "body": ["const [${1:name}, set${1/(.*)/${0:/capitalize}/}] = useState${0}(${2});"]
+  },
+  "React Page Component": {
+    "prefix": "!rpc",
+    "description": "페이지 컴포넌트를 만든다.",
+    "body": [
+      "import { useEffect } from 'react';",
+      "import { useDispatch } from 'react-redux';",
+      "import { useQueryParams } from 'jordy';",
+      "import { PageContainer } from '@shared/containers/PageContainer';",
+      "import { AppDispatch } from '@common/store';",
+      "import { ${3:ParamsModel} } from '../models';",
+      "import { refine${3} } from '../manipulates';",
+      "",
+      "function $TM_FILENAME_BASE() {",
+      "  const dispatch = useDispatch<AppDispatch>();",
+      "  const params = useQueryParams(refine${3});",
+      "",
+      "  useEffect(() => {",
+      "    dispatch(effSomeAction())",
+      "  }, []);",
+      "",
+      "  return (",
+      "    <PageContainer title=\"\">",
+      "      $0",
+      "    </PageContainer>",
+      "  );",
+      "};",
+      "",
+      "export default $TM_FILENAME_BASE;",
+      ""
+    ]
+  },
+  "React Container Component": {
+    "prefix": "!rcc",
+    "description": "컨테이너 컴포넌트를 만든다.",
+    "body": [
+      "import { ReactNode } from 'react';",
+      "import { useDispatch, useSelector } from 'react-redux';",
+      "",
+      "// eslint-disable-next-line @typescript-eslint/no-empty-interface",
+      "interface ${4:${TM_FILENAME_BASE}Props} {",
+      "  children?: ReactNode;",
+      "}",
+      "",
+      "export function $TM_FILENAME_BASE({",
+      "  children,",
+      "}: $4) {",
+      "  const dispatch = useDispatch();",
+      "  const state = useSelector();",
+      "",
+      "  return (",
+      "    <${10:${TM_FILENAME_BASE/\\Container//gi}}>",
+      "    </${10:${TM_FILENAME_BASE/\\Container//gi}}>",
+      "  );",
+      "};",
+      ""
+    ]
+  },
+  "React Single Function Component": {
+    "prefix": "!rc",
+    "description": "함수형 컴포넌트를 만든다. - 단순한 단일형 컴포넌트.",
+    "body": [
+      "import { ReactNode } from 'react';",
+      "import styled from 'styled-components';",
+      "",
+      "interface ${1:${TM_FILENAME_BASE}Props} {",
+      "  children?: ReactNode;",
+      "}",
+      "",
+      "const ${3:Wrap} = styled.${2:div}`",
+      "",
+      "`;",
+      "",
+      "export function $TM_FILENAME_BASE({",
+      "  children,",
+      "}: $1) {",
+      "  return (",
+      "    <${3:Wrap}>",
+      "      {children}",
+      "    </${3:Wrap}>",
+      "  );",
+      "};",
+      ""
+    ]
+  },
+ 
+  
+  "React Storybook Visual Test - Make Sub": {
+    "prefix": "!rcssub",
+    "description": "스토리북을 통한 하위 리액트 비주얼 테스트 코드를 만든다",
+    "body": [
+      "const ${2:Some}Template: StoryFn<StoryProps> = ({ ...props }) => {",
+      "  const [state, setState] = useState(props);",
+      "  return (",
+      "    <${1:${TM_FILENAME_BASE/\\.stories//gi}} {...props}></${1}>",
+      "  );",
+      "};",
+      "",
+      "export const ${2}: StoryObj<StoryProps> = {",
+      "  render: ${2:Some}Template,",
+      "",
+      "  args: {",
+      "    ...Default.args,",
+      "    ${0}",
+      "  },",
+      "};"
+    ]
+  },
+  "React Storybook Visual Test - Make Sub From Template": {
+    "prefix": "!rcst",
+    "description": "스토리북을 통한 하위 리액트 비주얼 테스트 코드를 만든다. 만들어진 스토리 템플릿을 재활용시 쓰인다.",
+    "body": [
+      "export const ${2:Some}: StoryObj<StoryProps> = {",
+      "  render: ${3:}Template,",
+      "",
+      "  args: {",
+      "    ...Default.args,",
+      "    ${0}",
+      "  },",
+      "};",
+    ]
+  },
+  "react Storybook - ArgType making with select options": {
+    "prefix": "!sbarg",
+    "description": "스토리북 argType 을 선택 옵션과 함께 만든다.",
+    "body": [
+      ": {",
+      "  control: '${1|radio,inline-radio,select,date,color|}',",
+      "  type: {",
+      "    name: '${2|enum,union,array,string,number,boolean,object,other|}',",
+      "    ${3:value: [],}",
+      "  },",
+      "},"
+    ]
+  },
+}

--- a/cli-assets/templates/component-dialog.tsx.handlebars
+++ b/cli-assets/templates/component-dialog.tsx.handlebars
@@ -64,7 +64,7 @@ export const {{fileName}} = forwardRef<
     {/* TODO: 프로젝트 내에서 쓰이는 모달 or 다이얼로그 컴포넌트로 변경 할 것 */}
     <Modal
       title="제목"
-      visible={show}
+      open={show}
       cancelText="취소"
       okText="확인"
       onCancel={handleCancel}

--- a/cli-assets/templates/storybook-dialog.stories.tsx.handlebars
+++ b/cli-assets/templates/storybook-dialog.stories.tsx.handlebars
@@ -1,18 +1,16 @@
 /* eslint-disable no-alert */
 import { ComponentProps, useRef, useEffect } from 'react';
 import { actions } from '@storybook/addon-actions';
-import { Story, Meta, ArgTypes } from '@storybook/react';
+import { StoryFn, StoryObj, Meta, ArgTypes } from '@storybook/react';
 import styled from 'styled-components';
 import { {{fileName}}, {{fileName}}Handle } from '../{{fileName}}';
 
 interface StoryProps extends ComponentProps<typeof {{fileName}}> {
+  defaultShow?: boolean;
 }
 
 type MyArgTypes = Partial<Record<keyof StoryProps, ArgTypes[string]>>;
 const argTypesSetting: MyArgTypes = {
-  defaultShow: {
-    control: 'boolean',
-  },
 };
 
 export default {
@@ -31,7 +29,7 @@ const Button = styled.button`
 
 const modalEvent = actions('onTestModalFinish', 'onTestModalError');
 
-const Template: Story<StoryProps> = ({ defaultShow, ...props }) => {
+const Template: StoryFn<StoryProps>= ({ defaultShow, ...props }) => {
   const refModal = useRef<{{fileName}}Handle>(null);
 
   const handleOpen = () => {
@@ -53,13 +51,17 @@ const Template: Story<StoryProps> = ({ defaultShow, ...props }) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
-  defaultShow: true,
+export const Default: StoryObj<StoryProps> = {
+  render: Template,
+  args: {
+    defaultShow: true,
+  },
 };
 
-export const WithTrigger = Template.bind({});
-WithTrigger.args = {
-  ...Default.args,
-  defaultShow: false,
+export const WithTrigger: StoryObj<StoryProps> = {
+  render: Template,
+  args: {
+    ...Default.args,
+    defaultShow: false,
+  },
 };

--- a/cli-assets/templates/storybook-imperative.stories.tsx.handlebars
+++ b/cli-assets/templates/storybook-imperative.stories.tsx.handlebars
@@ -1,7 +1,7 @@
 /* eslint-disable no-alert */
 import { ComponentProps, useRef, useEffect } from 'react';
 import { actions } from '@storybook/addon-actions';
-import { Story, Meta, ArgTypes } from '@storybook/react';
+import { StoryFn, StoryObj, Meta, ArgTypes } from '@storybook/react';
 import styled from 'styled-components';
 import { {{fileName}}, {{fileName}}Handle } from '../{{fileName}}';
 
@@ -28,7 +28,7 @@ const Button = styled.button`
 
 const actionHandlers = actions('onTestMethod1');
 
-const Template: Story<StoryProps> = ({ ...props }) => {
+const Template: StoryFn<StoryProps> = ({ ...props }) => {
   const ref = useRef<{{fileName}}Handle>(null);
 
   const getInstance = () => {
@@ -54,6 +54,9 @@ const Template: Story<StoryProps> = ({ ...props }) => {
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const Default: StoryObj<StoryProps> = {
+  render: Template,
+  args: {
+    
+  },
 };

--- a/cli-assets/templates/storybook-normal.stories.tsx.handlebars
+++ b/cli-assets/templates/storybook-normal.stories.tsx.handlebars
@@ -1,6 +1,6 @@
 /* eslint-disable no-alert */
 import { ComponentProps } from 'react';
-import { Story, Meta, ArgTypes } from '@storybook/react';
+import { StoryFn, StoryObj, Meta, ArgTypes } from '@storybook/react';
 import { {{fileName}} } from '../{{fileName}}';
 
 interface StoryProps extends ComponentProps<typeof {{fileName}}> {
@@ -17,12 +17,14 @@ export default {
   parameters: { actions: { argTypesRegex: '^on.*' } }
 } as Meta;
 
-const Template: Story<StoryProps> = ({ ...props }) => {
+const Template: StoryFn<StoryProps> = ({ ...props }) => {
   return (
     <{{fileName}} {...props}></{{fileName}}>
   );
 };
 
-export const Default = Template.bind({});
-Default.args = {
+export const Default: StoryObj<StoryProps> = {
+  render: Template,
+  args: {
+  },
 };

--- a/cli-test.sh
+++ b/cli-test.sh
@@ -12,3 +12,4 @@ node bin ui ./src/ui/components/design/system/tag/someSome OtherTag
 node bin ui ./src/ui/components/design ItsMyLifeMusicView imperative
 node bin ui ./src/ui/components/design/system/ OhMyLookpinForm imperative
 node bin ui ./src/ui/components/lookpin LookpinView
+node bin snippets

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jordy-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "CLI tool for front-end develop with jordy library",
   "main": "./build/index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "test:watch": "vitest watch",
     "prettier": "prettier './packages/**/*.ts'",
     "lint": "eslint 'packages/**'",
-    "clean:src": "rimraf src",
+    "clean:src": "rimraf src && rimraf .vscode",
     "test:cli": "sh ./cli-test.sh"
   },
   "bin": {

--- a/packages/code-generator/cli.ts
+++ b/packages/code-generator/cli.ts
@@ -18,6 +18,21 @@ async function getDefaultConfig() {
   return JSON.parse(jsonConfig) as CodeGeneratorModuleConfigDto;
 }
 
+function getSnippetsFilePath() {
+  const basePath = `${__dirname}/../${CLI_ASSETS_NAME}/snippets`;
+  const fileNames = [
+    'typescript.code-snippets',
+    'typescriptreact.code-snippets',
+  ];
+
+  return fileNames.map((fileName) => {
+    return {
+      src: `${basePath}/${fileName}`,
+      dest: `./.vscode/${fileName}`,
+    };
+  });
+}
+
 export default async function codeGeneratorCLI() {
   const program = new Command();
   const service = createCodeFileWriterService();
@@ -95,6 +110,15 @@ export default async function codeGeneratorCLI() {
 
       console.log('sb', path, type, fileInfo);
     });
+
+  program.command('snippets').action(async () => {
+    await fs.mkdir('./.vscode', { recursive: true });
+    await Promise.all(
+      getSnippetsFilePath().map(({ src, dest }) => fs.copyFile(src, dest))
+    );
+
+    console.log('snippets - copy success!');
+  });
 
   program.parse(process.argv);
 }


### PR DESCRIPTION
## Updates <!-- 추가 되거나 바뀐 내용 -->

- 최근 프로젝트의 스토리북 버전이 7.0 으로 올라감에 따라 생성되는 스토리북 테스트 코드 역시 7.0 기반으로 템플릿 내용을 변경합니다.
- 스니펫 파일을 복사하는 커맨트를 추가합니다.
  - `npm run cli snippets` 를 치면 됩니다~!
